### PR TITLE
style: make demo easier to read

### DIFF
--- a/examples/demo/demo.js
+++ b/examples/demo/demo.js
@@ -50,17 +50,47 @@ let ruleset = {
 
 export default class DemoQueryBuilder extends Component {
     getChildren(props) {
+        const jsonStyle = { backgroundColor: 'darkgrey', margin: '10px', padding: '10px' } 
         return (
-            <div>
+            <div style={{padding: '10px'}}>
                 <div className="query-builder">
                     <Builder {...props} />
                 </div>
                 <br />
-                <div>queryBuilderFormat: {stringify(queryBuilderFormat(props.tree, props.config))}</div>
-                <div>stringFormat: {queryString(props.tree, props.config)}</div>
-                <div>humanStringFormat: {queryString(props.tree, props.config, true)}</div>
-                <div>Tree: {stringify(props.tree)}</div>
-                <div>Immutable Tree: {transit.toJSON(props.tree)}</div>
+                <div>
+                  queryBuilderFormat: 
+                    <pre style={jsonStyle}>
+                      {stringify(queryBuilderFormat(props.tree, props.config), undefined, 2)}
+                    </pre>
+                </div>
+                <hr/>
+                <div>
+                  stringFormat: 
+                  <pre style={jsonStyle}>
+                    {stringify(queryString(props.tree, props.config), undefined, 2)}
+                  </pre>
+                </div>
+                <hr/>
+                <div>
+                  humanStringFormat: 
+                  <pre style={jsonStyle}>
+                    {stringify(queryString(props.tree, props.config, true), undefined, 2)}
+                  </pre>
+                </div>
+                <hr/>
+                <div>
+                  Tree: 
+                  <pre style={jsonStyle}>
+                    {stringify(props.tree, undefined, 2)}
+                  </pre>
+                </div>
+                <hr/>
+                <div>
+                  Immutable Tree: 
+                  <div style={jsonStyle}>
+                    {transit.toJSON(props.tree)}
+                  </div>
+                </div>
             </div>
         )
     }
@@ -81,4 +111,3 @@ export default class DemoQueryBuilder extends Component {
         );
     }
 }
-


### PR DESCRIPTION
Make the demo easier to read by displaying the JSON in a pretty format. 
  
<img width="1388" alt="screen shot 2018-01-05 at 1 33 59 pm" src="https://user-images.githubusercontent.com/1231554/34625894-17eb769e-f220-11e7-90e6-3e3bb4fa63ca.png">
