### PR TITLE
refactor: add tableName work in queryBuilderFormat

### DIFF
--- a/modules/utils/queryBuilderFormat.js
+++ b/modules/utils/queryBuilderFormat.js
@@ -77,9 +77,9 @@ export const queryBuilderFormat = (item, config, rootQuery = null) => {
 
         return resultQuery;
     } else if (type === 'rule') {
-        const field = properties.get('field');
         const operator = properties.get('operator');
         const options = properties.get('operatorOptions');
+        let field = properties.get('field');
         let value = properties.get('value');
         let valueSrc = properties.get('valueSrc');
         let valueType = properties.get('valueType');
@@ -104,6 +104,12 @@ export const queryBuilderFormat = (item, config, rootQuery = null) => {
         const widget = getWidgetForFieldOp(config, field, operator);
         const fieldWidgetDefinition = omit(getFieldWidgetConfig(config, field, operator, widget), ['factory']);
         const typeConfig = config.types[fieldDefinition.type] || {};
+
+        //format field
+        if (fieldDefinition.tableName) {
+          const regex = new RegExp(field.split(config.settings.fieldSeparator)[0])
+          field = field.replace(regex, fieldDefinition.tableName)
+        }
 
         if (value.size < cardinality)
             return undefined;


### PR DESCRIPTION
Make the tableName option work inside of the queryBuilderFormat. For a visual of what I mean, this is the current generated queryBuilderFormat:

<img width="1388" alt="screen shot 2018-01-08 at 9 54 42 am" src="https://user-images.githubusercontent.com/1231554/34679116-8f82e0f2-f45a-11e7-970b-daf771ae2ff0.png">

and this will be the new output:

<img width="1388" alt="screen shot 2018-01-08 at 9 54 29 am" src="https://user-images.githubusercontent.com/1231554/34679122-967809fa-f45a-11e7-908e-df145a7ac487.png">
