### PR TITLE
feat: add group actions position settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ export default {
     customFieldSelectProps: {
         showSearch: true
     },
+    // You can change the position of the group actions to the following:
+    // oneOf [topLeft, topCenter, topRight (default), bottomLeft, bottomCenter, bottomRight]
+    groupActionsPosition: 'topRight', 
+    groupActionsPositionList: {
+      topLeft: 'group--actions--tl',
+      topCenter: 'group--actions--tc',
+      topRight: 'group--actions--tr',
+      bottomLeft: 'group--actions--bl',
+      bottomCenter: 'group--actions--bc',
+      bottomRight: 'group--actions--br'
+    },
     //Strategies for selecting operator for new field (used by order until success)
     // 'default' (default if present), 'keep' (keep prev from last field), 'first', 'none'
     setOpOnChangeField: ['keep', 'default'],

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -1,3 +1,8 @@
+@mixin flex{
+  display: flex;
+  align-items: center;
+}
+
 @mixin clearfix {
   &:after {
     content: "";
@@ -20,6 +25,10 @@
 
 %clearfix {
   @include clearfix;
+}
+
+%flex{
+  @include flex;
 }
 
 .query-builder {
@@ -94,6 +103,10 @@
 /******************************************************************************/
 /** GROUP *********************************************************************/
 /******************************************************************************/
+.group--header,
+.group--footer{
+  @extend %flex;
+}
 
 .group--children {
   padding-left: 20px;
@@ -162,22 +175,41 @@
   cursor: grabbing;
 }
 
-.group--header {
-  @extend %clearfix;
-  padding: 10px;
-  padding-left: 5px;
+.group--header,
+.group--footer {
+  padding: {
+    top: 10px;
+    right: 5px;
+    bottom: 10px;
+    left: 10px;
+  }
 }
 
-
-.group--conjunctions {
-  float: left;
-}
 .group--conjunctions.hide--conj {
     opacity: 0.3;
 }
 
 .group--actions {
-  float: right;
+  flex: 1;
+  display: flex;
+  &--tl,
+  &--bl{
+    justify-content: flex-start;
+  }
+
+  &--tl{
+    margin-left: 20px;
+  }
+
+  &--tc,
+  &--bc {
+    justify-content: center;
+  }
+
+  &--tr,
+  &--br{
+    justify-content: flex-end;
+  }
 }
 
 /******************************************************************************/

--- a/examples/demo/config.js
+++ b/examples/demo/config.js
@@ -649,6 +649,15 @@ export default {
         customFieldSelectProps: {
             showSearch: true
         },
+        groupActionsPosition: 'topRight', // oneOf [topLeft, topCenter, topRight, bottomLeft, bottomCenter, bottomRight]
+        groupActionsPositionList: {
+          topLeft: 'group--actions--tl',
+          topCenter: 'group--actions--tc',
+          topRight: 'group--actions--tr',
+          bottomLeft: 'group--actions--bl',
+          bottomCenter: 'group--actions--bc',
+          bottomRight: 'group--actions--br'
+        },
         setOpOnChangeField: ['keep', 'default'], // 'default' (default if present), 'keep' (keep prev from last field), 'first', 'none'
         clearValueOnChangeField: false, //false - if prev & next fields have same type (widget), keep
         clearValueOnChangeOp: false,

--- a/modules/components/Group.js
+++ b/modules/components/Group.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import map from 'lodash/map';
+import startsWith from 'lodash/startsWith'
 import GroupContainer from './containers/GroupContainer';
 import { Row, Col, Icon, Button, Radio } from 'antd';
 const ButtonGroup = Button.Group;
@@ -35,31 +36,71 @@ export default class Group extends Component {
 
   shouldComponentUpdate = shallowCompare;
 
-    handleDraggerMouseDown (e) {
-        var nodeId = this.props.id;
-        var dom = this.refs.group;
-        if (this.props.onDragStart) {
-          this.props.onDragStart(nodeId, dom, e);
-        }
+  handleDraggerMouseDown (e) {
+    var nodeId = this.props.id;
+    var dom = this.refs.group;
+    if (this.props.onDragStart) {
+      this.props.onDragStart(nodeId, dom, e);
     }
+  }
+
+  getGroupPositionClass = () => {
+    const { groupActionsPosition, groupActionsPositionList } = this.props.config.settings
+    return groupActionsPositionList[groupActionsPosition] || 'group--actions--tr'
+  }
+
+  isGroupTopPosition = () => {
+    return startsWith(this.props.config.settings.groupActionsPosition || 'topRight', 'top')
+  }
+
+  renderGroup = (position) => {
+    return (
+      <div className={`group--actions ${position}`}>
+        <ButtonGroup
+          size={this.props.config.settings.renderSize || "small"}
+        >
+          <Button
+            icon="plus"
+            className="action action--ADD-RULE"
+            onClick={this.props.addRule}
+          >{this.props.config.settings.addRuleLabel || "Add rule"}</Button>
+          {this.props.allowFurtherNesting ? (
+            <Button
+              className="action action--ADD-GROUP"
+              icon="plus-circle-o"
+              onClick={this.props.addGroup}
+            >{this.props.config.settings.addGroupLabel || "Add group"}</Button>
+          ) : null}
+          {!this.props.isRoot ? (
+            <Button
+              type="danger"
+              icon="delete"
+              className="action action--ADD-DELETE"
+              onClick={this.props.removeSelf}
+            >{this.props.config.settings.delGroupLabel !== undefined ? this.props.config.settings.delGroupLabel : "Delete"}</Button>
+          ) : null}
+        </ButtonGroup>
+      </div>
+    )
+  }
 
   render() {
     let renderConjsAsRadios = false;
 
     let styles = {};
     if (this.props.renderType == 'dragging') {
-        styles = {
-            top: this.props.dragging.y,
-            left: this.props.dragging.x,
-            width: this.props.dragging.w
-        };
+      styles = {
+        top: this.props.dragging.y,
+        left: this.props.dragging.x,
+        width: this.props.dragging.w
+      };
     }
 
     return (
       <div
         className={classNames("group", "group-or-rule",
-            this.props.renderType == 'placeholder' ? 'qb-placeholder' : null,
-            this.props.renderType == 'dragging' ? 'qb-draggable' : null,
+          this.props.renderType == 'placeholder' ? 'qb-placeholder' : null,
+          this.props.renderType == 'dragging' ? 'qb-draggable' : null,
         )}
         style={styles}
         ref="group"
@@ -70,25 +111,25 @@ export default class Group extends Component {
             "group--conjunctions",
             this.props.children.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--conj' : ''
           )}>
-            { this.props.config.settings.renderConjsAsRadios ?
-              <RadioGroup
-                 disabled={this.props.children.size < 2}
-                 value={this.props.selectedConjunction}
-                 size={this.props.config.settings.renderSize || "small"}
-                 onChange={this.props.setConjunction}
-              >
+          { this.props.config.settings.renderConjsAsRadios ?
+            <RadioGroup
+              disabled={this.props.children.size < 2}
+              value={this.props.selectedConjunction}
+              size={this.props.config.settings.renderSize || "small"}
+              onChange={this.props.setConjunction}
+            >
               {map(this.props.conjunctionOptions, (item, index) => (
                 <RadioButton
                   value={item.key}
                   //checked={item.checked}
                 >{item.label}</RadioButton>
               ))}
-              </RadioGroup>
+            </RadioGroup>
             :
-              <ButtonGroup
-                size={this.props.config.settings.renderSize || "small"}
-                disabled={this.props.children.size < 2}
-              >
+            <ButtonGroup
+              size={this.props.config.settings.renderSize || "small"}
+              disabled={this.props.children.size < 2}
+            >
               {map(this.props.conjunctionOptions, (item, index) => (
                 <Button
                   disabled={this.props.children.size < 2}
@@ -97,46 +138,26 @@ export default class Group extends Component {
                   onClick={(ev) => this.props.setConjunction(ev, item.key)}
                 >{item.label}</Button>
               ))}
-              </ButtonGroup>
-            }
-            { this.props.config.settings.canReorder && this.props.treeNodesCnt > 2 && !this.props.isRoot &&
-                <span className={"qb-drag-handler"} onMouseDown={this.handleDraggerMouseDown.bind(this)} > <Icon type="bars" /> </span>
-            }
-          </div>
-          <div className="group--actions">
-            <ButtonGroup
-              size={this.props.config.settings.renderSize || "small"}
-            >
-                <Button
-                  icon="plus"
-                  className="action action--ADD-RULE"
-                  onClick={this.props.addRule}
-                >{this.props.config.settings.addRuleLabel || "Add rule"}</Button>
-                {this.props.allowFurtherNesting ? (
-                  <Button
-                    className="action action--ADD-GROUP"
-                    icon="plus-circle-o"
-                    onClick={this.props.addGroup}
-                  >{this.props.config.settings.addGroupLabel || "Add group"}</Button>
-                ) : null}
-                {!this.props.isRoot ? (
-                  <Button
-                    type="danger"
-                    icon="delete"
-                    className="action action--ADD-DELETE"
-                    onClick={this.props.removeSelf}
-                  >{this.props.config.settings.delGroupLabel !== undefined ? this.props.config.settings.delGroupLabel : "Delete"}</Button>
-                ) : null}
             </ButtonGroup>
-          </div>
+          }
+          { this.props.config.settings.canReorder && this.props.treeNodesCnt > 2 && !this.props.isRoot &&
+              <span className={"qb-drag-handler"} onMouseDown={this.handleDraggerMouseDown.bind(this)} > <Icon type="bars" /> </span>
+          }
         </div>
-        {this.props.children ? (
-          <div className={classNames(
-            "group--children",
-            this.props.children.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : ''
-          )}>{this.props.children}</div>
-        ) : null}
+      {this.isGroupTopPosition() && this.renderGroup(this.getGroupPositionClass())}
       </div>
+      {this.props.children ? (
+        <div className={classNames(
+          "group--children",
+          this.props.children.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : ''
+        )}>{this.props.children}</div>
+      ) : null}
+      {!this.isGroupTopPosition() && (
+          <div className='group--footer'>
+            {this.renderGroup(this.getGroupPositionClass())}
+          </div>
+      )}
+    </div>
     );
   }
 }


### PR DESCRIPTION
Change `groupActionsPosition` inside your `config.js` to any of the following:

* `topLeft` 
* `topCenter`
* `topRight`
* `bottomLeft`
* `bottomCenter` 
* `bottomRight`


Top Left:
<img width="1171" alt="qbuilder-tl" src="https://user-images.githubusercontent.com/1252222/35526049-eebcff3e-04eb-11e8-9844-59966e9db7f1.png">

Top Center:
<img width="1163" alt="qbuilder-tc" src="https://user-images.githubusercontent.com/1252222/35526112-0cc783aa-04ec-11e8-9fe3-76cdb5c84d47.png">

Top Right:
<img width="1164" alt="qbuilder-tr" src="https://user-images.githubusercontent.com/1252222/35526131-173a9e08-04ec-11e8-851e-eb9bcb2dd26f.png">

Bottom Left:
<img width="1165" alt="qbuilder-bl" src="https://user-images.githubusercontent.com/1252222/35526149-23724b26-04ec-11e8-8a9a-21bf9bbc9e4d.png">

Bottom Center:
<img width="1169" alt="qbuilder-bc" src="https://user-images.githubusercontent.com/1252222/35526161-30cea76a-04ec-11e8-9707-bb5469f74288.png">

Bottom Right:
<img width="1161" alt="qbuilder-br" src="https://user-images.githubusercontent.com/1252222/35526185-3e3f1290-04ec-11e8-8815-3ec40f10df98.png">
