### PR TITLE
Alter state update logic

### DIFF
--- a/modules/components/Query.js
+++ b/modules/components/Query.js
@@ -8,6 +8,7 @@ import {extendConfig} from "../utils/configUtils";
 import {fixPathsInTree} from '../utils/treeUtils';
 import {bindActionCreators} from "../utils/stuff";
 import {validateTree} from "../utils/validation";
+import {queryString} from "../utils/queryString";
 import { LocaleProvider } from 'antd';
 import Immutable from 'immutable';
 
@@ -125,13 +126,13 @@ export default class Query extends Component {
 
     // handle case when value property changes
     componentWillReceiveProps(nextProps) {
-      var tree = nextProps.value;
-      var oldTree = this.props.tree;
-      if (tree !== oldTree) {
-        //TODO: This causes infinite loop! Dispatch in updating lifecycle methods is evil!
-        //this.state.store.dispatch(
-        //  actions.tree.setTree(this.props.config, tree)
-        //)
+      var previousQueryString = queryString(this.props.value, this.props);
+      var nextQueryString = queryString(nextProps.value, nextProps);
+
+      if (previousQueryString !== nextQueryString) {
+        this.state.store.dispatch(
+          actions.tree.setTree(nextProps, nextProps.value)
+        );
       }
     }
 

--- a/modules/components/Query.js
+++ b/modules/components/Query.js
@@ -137,7 +137,7 @@ export default class Query extends Component {
       if (previousQueryString !== nextQueryString) {
           let nextTree = nextProps.value || defaultRoot({ ...nextProps, tree: null });
           this.state.store.dispatch(
-              actions.tree.setTree(nextProps, nextTree);
+              actions.tree.setTree(nextProps, nextTree)
           );
       }
     }

--- a/modules/components/Query.js
+++ b/modules/components/Query.js
@@ -9,6 +9,7 @@ import {fixPathsInTree} from '../utils/treeUtils';
 import {bindActionCreators} from "../utils/stuff";
 import {validateTree} from "../utils/validation";
 import {queryString} from "../utils/queryString";
+import {defaultRoot} from "../utils/defaultUtils";
 import { LocaleProvider } from 'antd';
 import Immutable from 'immutable';
 

--- a/modules/components/Query.js
+++ b/modules/components/Query.js
@@ -126,13 +126,18 @@ export default class Query extends Component {
 
     // handle case when value property changes
     componentWillReceiveProps(nextProps) {
-      var previousQueryString = queryString(this.props.value, this.props);
-      var nextQueryString = queryString(nextProps.value, nextProps);
+      let getQueryStringForProps = (props) => props.value != null
+          ? queryString(props.value, props)
+          : '';
+      let previousQueryString = getQueryStringForProps(this.props);
+      let nextQueryString = getQueryStringForProps(nextProps);
 
+      // compare stringified trees
       if (previousQueryString !== nextQueryString) {
-        this.state.store.dispatch(
-          actions.tree.setTree(nextProps, nextProps.value)
-        );
+          let nextTree = nextProps.value || defaultRoot({ ...nextProps, tree: null });
+          this.state.store.dispatch(
+              actions.tree.setTree(nextProps, nextTree);
+          );
       }
     }
 


### PR DESCRIPTION
This commit changes the logic inside `willComponentReceiveProps` method so it updates the store only when it's really required.

Resolves https://github.com/ukrbublik/react-awesome-query-builder/issues/37

cc: @ukrbublik 