### PR TITLE
Improve size calcuation

### DIFF
--- a/modules/utils/stuff.js
+++ b/modules/utils/stuff.js
@@ -18,11 +18,11 @@ export const bindActionCreators = (actionCreators, config, dispatch) =>
 
 
 export const calcTextWidth = function(str, font) {
-  var f = font || '12px';
+  var f = '1.3em';
   var div = document.createElement("div");
   div.innerHTML = str;
   var css = {
-    'position': 'absolute', 'float': 'left', 'white-space': 'nowrap', 'visibility': 'hidden', 'font': f
+    'position': 'absolute', 'float': 'left', 'white-space': 'nowrap', 'visibility': 'hidden', 'font-size': f
   };
   for (let k in css) {
     div.style[k] = css[k];


### PR DESCRIPTION
You can use `em` CSS unit instead of hardcoding values for size. This one works with your font and other fonts.