### PR TITLE
Use ConfigProvider instead of LocaleProvider (fixes #97)

### DIFF
--- a/modules/components/Query.js
+++ b/modules/components/Query.js
@@ -10,7 +10,7 @@ import {bindActionCreators} from "../utils/stuff";
 import {validateTree} from "../utils/validation";
 import {queryString} from "../utils/queryString";
 import {defaultRoot} from "../utils/defaultUtils";
-import { LocaleProvider } from 'antd';
+import { ConfigProvider } from 'antd';
 import Immutable from 'immutable';
 
 
@@ -151,7 +151,7 @@ export default class Query extends Component {
         config = extendConfig(config);
 
         return (
-            <LocaleProvider locale={config.settings.locale.antd}>
+            <ConfigProvider locale={config.settings.locale.antd}>
                 <Provider store={this.state.store}>
                     <QueryContainer
                       store={this.state.store}
@@ -160,7 +160,7 @@ export default class Query extends Component {
                       onChange={onChange}
                     />
                 </Provider>
-            </LocaleProvider>
+            </ConfigProvider>
         )
     }
 }

--- a/modules/components/widgets/Time.js
+++ b/modules/components/widgets/Time.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TimePicker } from 'antd';
 import moment from 'moment';
-import { LocaleProvider } from 'antd';
 import shallowCompare from 'react-addons-shallow-compare';
 
 


### PR DESCRIPTION
Removed use of `LocaleProvider` and replaced with `ConfigProvider locale=....>`