### PR TITLE
Add support for rule results handling

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -259,7 +259,12 @@ body.qb-dragging {
   margin-right: 8px;
 }
 
-.rule--field, .rule--operator, .rule--value, .rule--operator-options, .rule--widget, 
+.rule--result {
+  right: 20%;
+  position: absolute;
+}
+
+.rule--field, .rule--operator, .rule--value, .rule--operator-options, .rule--widget, .rule--result,
 .widget--widget, .widget--valuesrc, .widget--sep, .operator--options--sep {
   display: inline-block;
 }

--- a/examples/demo/demo.tsx
+++ b/examples/demo/demo.tsx
@@ -2,36 +2,37 @@ import React, {Component} from 'react';
 import {
   Query, Builder, BasicConfig, Utils, 
   //types:
-  ImmutableTree, Config, BuilderProps, JsonTree
+  ImmutableTree, Config, BuilderProps, JsonTree, RuleResultProps
 } from 'react-awesome-query-builder';
 import throttle from 'lodash/throttle';
 import loadedConfig from './config';
 import loadedInitValue from './init_value';
 
 const stringify = JSON.stringify;
-const {queryBuilderFormat, jsonLogicFormat, queryString, mongodbFormat, sqlFormat, getTree, checkTree, loadTree, uuid} = Utils;
+const {queryBuilderFormat, jsonLogicFormat, queryString, mongodbFormat, sqlFormat, getTree, checkTree, loadTree, uuid, getFlatTree } = Utils;
 const preStyle = { backgroundColor: 'darkgrey', margin: '10px', padding: '10px' };
 const preErrorStyle = { backgroundColor: 'lightpink', margin: '10px', padding: '10px' };
 
 const emptyInitValue: JsonTree = {id: uuid(), type: "group"};
 const initValue: JsonTree = loadedInitValue && Object.keys(loadedInitValue).length > 0 ? loadedInitValue as JsonTree : emptyInitValue;
 
-
-
 interface DemoQueryBuilderState {
   tree: ImmutableTree;
   config: Config;
+  ruleResults: RuleResultProps[];
 }
 
 export default class DemoQueryBuilder extends Component<{}, DemoQueryBuilderState> {
     private immutableTree: ImmutableTree;
     private config: Config;
+    private ruleResults: RuleResultProps [];
 
     state = {
       tree: checkTree(loadTree(initValue), loadedConfig),
-      config: loadedConfig
+      config: loadedConfig,
+      ruleResults: []
     };
-
+ 
     render = () => (
       <div>
         <Query
@@ -46,30 +47,52 @@ export default class DemoQueryBuilder extends Component<{}, DemoQueryBuilderStat
       </div>
     )
 
-    renderBuilder = (props: BuilderProps) => (
+    renderBuilder = (props: BuilderProps) => {
+      return (
+      
       <div className="query-builder-container" style={{padding: '10px'}}>
           <div className="query-builder qb-lite">
-              <Builder {...props} />
+              <Builder 
+                {...props} 
+                customData={{ruleResults: this.state.ruleResults}} 
+              />
           </div>
       </div>
     )
+  }
     
     onChange = (immutableTree: ImmutableTree, config: Config) => {
       this.immutableTree = immutableTree;
       this.config = config;
+      this.queryBackend();
       this.updateResult();
-      const jsonTree = getTree(immutableTree); //can be saved to backend
     }
 
     updateResult = throttle(() => {
-      this.setState({tree: this.immutableTree, config: this.config});
+      this.setState({tree: this.immutableTree, config: this.config, ruleResults: this.ruleResults});
     }, 100)
+
+    queryBackend() {
+      const jsonTree = getTree(this.immutableTree); //can be saved to backend
+      const flatTree = getFlatTree(this.immutableTree);
+      this.ruleResults = flatTree.flat.map(x => { return { 
+        ruleId: x, 
+        filtered: Math.floor((Math.random() * 10000)), 
+        total: Math.floor((Math.random() * 100000) + 10000) }}) as RuleResultProps[];
+    }
 
     renderResult = ({tree: immutableTree, config} : {tree: ImmutableTree, config: Config}) => {
       const {logic, data, errors} = jsonLogicFormat(immutableTree, config);
       return (
       <div>
         <br />
+        <div>
+          queryBuilderFormat: 
+            <pre style={preStyle}>
+              {stringify(queryBuilderFormat(immutableTree, config), undefined, 2)}
+            </pre>
+        </div>
+        <hr/>
         <div>
           stringFormat: 
           <pre style={preStyle}>
@@ -122,13 +145,6 @@ export default class DemoQueryBuilder extends Component<{}, DemoQueryBuilderStat
             {stringify(getTree(immutableTree), undefined, 2)}
           </pre>
         </div>
-        {/* <hr/>
-        <div>
-          queryBuilderFormat: 
-            <pre style={preStyle}>
-              {stringify(queryBuilderFormat(immutableTree, config), undefined, 2)}
-            </pre>
-        </div> */}
       </div>
       )
   }

--- a/modules/components/Builder.jsx
+++ b/modules/components/Builder.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Immutable, {Map} from 'immutable';
+import Immutable, { Map } from 'immutable';
 import Item from '../components/Item';
 import SortableContainer from './containers/SortableContainer';
-import {getTotalNodesCountInTree} from "../utils/treeUtils";
+import { getTotalNodesCountInTree } from "../utils/treeUtils";
 import uuid from "../utils/uuid";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -15,27 +15,28 @@ export default class Builder extends Component {
     config: PropTypes.object.isRequired,
     actions: PropTypes.object.isRequired,
     onDragStart: PropTypes.func,
+    customData: PropTypes.any,
   };
 
   pureShouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
   shouldComponentUpdate(nextProps, nextState) {
-      const prevProps = this.props;
-      let should = this.pureShouldComponentUpdate(nextProps, nextState);
-      if (should) {
-        let chs = [];
-        for (let k in nextProps) {
-            let changed = (nextProps[k] !== prevProps[k]);
-            if (changed && k != '__isInternalValueChange') {
-              chs.push(k);
-            }
+    const prevProps = this.props;
+    let should = this.pureShouldComponentUpdate(nextProps, nextState);
+    if (should) {
+      let chs = [];
+      for (let k in nextProps) {
+        let changed = (nextProps[k] !== prevProps[k]);
+        if (changed && k != '__isInternalValueChange') {
+          chs.push(k);
         }
-        if (!chs.length)
-            should = false;
-        //optimize render
-        if (chs.length == 1 && chs[0] == 'tree' && nextProps.__isInternalValueChange)
-            should = false;
       }
-      return should;
+      if (!chs.length)
+        should = false;
+      //optimize render
+      if (chs.length == 1 && chs[0] == 'tree' && nextProps.__isInternalValueChange)
+        should = false;
+    }
+    return should;
   }
 
   constructor(props) {
@@ -44,7 +45,7 @@ export default class Builder extends Component {
     this._updPath(props);
   }
 
-  _updPath (props) {
+  _updPath(props) {
     const id = props.tree.get('id');
     this.path = Immutable.List.of(id);
   }
@@ -53,7 +54,7 @@ export default class Builder extends Component {
     const treeNodesCnt = getTotalNodesCountInTree(this.props.tree);
     const id = this.props.tree.get('id');
     return (
-      <Item 
+      <Item
         key={id}
         id={id}
         path={this.path}
@@ -65,6 +66,7 @@ export default class Builder extends Component {
         //tree={this.props.tree}
         treeNodesCnt={treeNodesCnt}
         onDragStart={this.props.onDragStart}
+        customData={this.props.customData}
       />
     );
   }

--- a/modules/components/Group.jsx
+++ b/modules/components/Group.jsx
@@ -7,8 +7,9 @@ import { Icon, Modal } from 'antd';
 const { confirm } = Modal;
 const classNames = require('classnames');
 import Item from './Item';
-import {ConjsRadios, ConjsButtons} from './Conjs';
-import {Actions} from './Actions';
+import { ConjsRadios, ConjsButtons } from './Conjs';
+import { Actions } from './Actions';
+import { RuleResultWrapper } from './Rule';
 
 const defaultPosition = 'topRight';
 
@@ -39,6 +40,7 @@ class Group extends PureComponent {
     setConjunction: PropTypes.func.isRequired,
     setNot: PropTypes.func.isRequired,
     actions: PropTypes.object.isRequired,
+    customData: PropTypes.any,
   };
 
   isGroupTopPosition = () => {
@@ -51,7 +53,8 @@ class Group extends PureComponent {
       this.props.removeSelf();
     };
     if (confirmOptions && !this.isEmptyCurrentGroup()) {
-      confirm({...confirmOptions,
+      confirm({
+        ...confirmOptions,
         onOk: doRemove,
         onCancel: null
       });
@@ -78,29 +81,32 @@ class Group extends PureComponent {
 
   isEmptyRule = (rule) => {
     const properties = rule.get('properties');
-      return !(
-          properties.get("field") !== null &&
-          properties.get("operator") !== null &&
-          properties.get("value").filter((val) => val !== undefined).size > 0
-      );
+    return !(
+      properties.get("field") !== null &&
+      properties.get("operator") !== null &&
+      properties.get("value").filter((val) => val !== undefined).size > 0
+    );
   }
 
   render() {
     const isGroupTopPosition = this.isGroupTopPosition();
+    const { showGroupResults } = this.props.config.settings;
+
     return [
-        <div key="group-header" className="group--header">
-          {this.renderHeader()}
-          {isGroupTopPosition && this.renderActions()}
-        </div>
-    , this.props.children1 &&
-        <div key="group-children" className={classNames(
-          "group--children",
-          this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : ''
-        )}>{this.renderChildren()}</div>
-    , !isGroupTopPosition &&
-        <div key="group-footer" className='group--footer'>
-          {this.renderActions()}
-        </div>
+      <div key="group-header" className="group--header">
+        {this.renderHeader()}
+        {showGroupResults && this.renderRuleResult()}
+        {isGroupTopPosition && this.renderActions()}
+      </div>
+      , this.props.children1 &&
+      <div key="group-children" className={classNames(
+        "group--children",
+        this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : ''
+      )}>{this.renderChildren()}</div>
+      , !isGroupTopPosition &&
+      <div key="group-footer" className='group--footer'>
+        {this.renderActions()}
+      </div>
     ];
   }
 
@@ -131,6 +137,7 @@ class Group extends PureComponent {
         //tree={props.tree}
         treeNodesCnt={props.treeNodesCnt}
         onDragStart={props.onDragStart}
+        customData={props.customData}
       />
     )).toList() : null;
   }
@@ -165,6 +172,15 @@ class Group extends PureComponent {
         {drag}
       </div>
     );
+  }
+
+  renderRuleResult = () => {
+    return <RuleResultWrapper
+      key="rule-result"
+      ruleId={this.props.id}
+      config={this.props.config}
+      customData={this.props.customData}
+    />
   }
 }
 

--- a/modules/components/Item.jsx
+++ b/modules/components/Item.jsx
@@ -6,7 +6,7 @@ import Group from './Group';
 
 const typeMap = {
   rule: (props) => (
-    <Rule 
+    <Rule
       {...props.properties.toObject()}
       id={props.id}
       path={props.path}
@@ -14,10 +14,11 @@ const typeMap = {
       treeNodesCnt={props.treeNodesCnt}
       config={props.config}
       onDragStart={props.onDragStart}
+      customData={props.customData}
     />
   ),
   group: (props) => (
-    <Group 
+    <Group
       {...props.properties.toObject()}
       id={props.id}
       path={props.path}
@@ -27,6 +28,7 @@ const typeMap = {
       treeNodesCnt={props.treeNodesCnt}
       onDragStart={props.onDragStart}
       children1={props.children1}
+      customData={props.customData}
     />
   )
 };
@@ -44,6 +46,7 @@ class Item extends PureComponent {
     actions: PropTypes.object.isRequired,
     treeNodesCnt: PropTypes.number,
     onDragStart: PropTypes.func,
+    customData: PropTypes.any,
   };
 
   render() {

--- a/modules/components/RuleResult.jsx
+++ b/modules/components/RuleResult.jsx
@@ -1,0 +1,21 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+export default class RuleResult extends PureComponent {
+  static propTypes = {
+    ruleId: PropTypes.string,
+    config: PropTypes.object.isRequired,
+    selectedField: PropTypes.string,
+    customProps: PropTypes.object,
+    result: PropTypes.object, //instanceOf(RuleResultProps),
+    emptyValue: PropTypes.string,
+  };
+
+  render() {
+    const { emptyValue } = this.props;
+    const { filtered, total } = this.props.ruleResult || { filtered: emptyValue, total: emptyValue };
+    return (
+      <span>{filtered}/{total}</span>
+    );
+  }
+}

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import mapValues from 'lodash/mapValues';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
 
 export default (Group) => {
@@ -20,6 +20,8 @@ export default (Group) => {
       treeNodesCnt: PropTypes.number,
       //connected:
       dragging: PropTypes.object, //{id, x, y, w, h}
+      //custom client data props
+      customData: PropTypes.any,
     };
 
     constructor(props) {
@@ -31,33 +33,33 @@ export default (Group) => {
     pureShouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
 
     shouldComponentUpdate(nextProps, nextState) {
-        let prevProps = this.props;
-        let prevState = this.state;
+      let prevProps = this.props;
+      let prevState = this.state;
 
-        let should = this.pureShouldComponentUpdate(nextProps, nextState);
-        if (should) {
-          if (prevState == nextState && prevProps != nextProps) {
-            const draggingId = (nextProps.dragging.id || prevProps.dragging.id);
-            const isDraggingMe = draggingId == nextProps.id;
-            let chs = [];
-            for (let k in nextProps) {
-                let changed = (nextProps[k] != prevProps[k]);
-                if (k == 'dragging' && !isDraggingMe) {
-                  changed = false; //dragging another item -> ignore
-                }
-                if (changed) {
-                  chs.push(k);
-                }
+      let should = this.pureShouldComponentUpdate(nextProps, nextState);
+      if (should) {
+        if (prevState == nextState && prevProps != nextProps) {
+          const draggingId = (nextProps.dragging.id || prevProps.dragging.id);
+          const isDraggingMe = draggingId == nextProps.id;
+          let chs = [];
+          for (let k in nextProps) {
+            let changed = (nextProps[k] != prevProps[k]);
+            if (k == 'dragging' && !isDraggingMe) {
+              changed = false; //dragging another item -> ignore
             }
-            if (!chs.length)
-                should = false;
+            if (changed) {
+              chs.push(k);
+            }
           }
+          if (!chs.length)
+            should = false;
         }
-        return should;
+      }
+      return should;
     }
 
     componentWillReceiveProps(nextProps) {
-      const {config, id, conjunction} = nextProps;
+      const { config, id, conjunction } = nextProps;
       const oldConfig = this.props.config;
       const oldConjunction = this.props.conjunction;
       if (oldConfig != config || oldConjunction != conjunction) {
@@ -65,7 +67,7 @@ export default (Group) => {
       }
     }
 
-    _getConjunctionOptions (props) {
+    _getConjunctionOptions(props) {
       return mapValues(props.config.conjunctions, (item, index) => ({
         id: `conjunction-${props.id}-${index}`,
         name: `conjunction[${props.id}]`,
@@ -88,7 +90,7 @@ export default (Group) => {
       this.props.actions.setNot(this.props.path, not);
     }
 
-    dummyFn = () => {}
+    dummyFn = () => { }
 
     removeSelf = () => {
       this.props.actions.removeGroup(this.props.path);
@@ -117,52 +119,54 @@ export default (Group) => {
           className={'group-or-rule-container group-container'}
           data-id={this.props.id}
         >
-        {[
-          isDraggingMe ? <Group
-            key={"dragging"}
-            id={this.props.id}
-            isDraggingMe={isDraggingMe}
-            isDraggingTempo={true}
-            dragging={this.props.dragging}
-            isRoot={isRoot}
-            allowFurtherNesting={allowFurtherNesting}
-            conjunctionOptions={this.conjunctionOptions}
-            not={this.props.not}
-            selectedConjunction={this.props.conjunction}
-            setConjunction={this.dummyFn}
-            setNot={this.dummyFn}
-            removeSelf={this.dummyFn}
-            addGroup={this.dummyFn}
-            addRule={this.dummyFn}
-            config={this.props.config}
-            children1={this.props.children1}
-            actions={this.props.actions}
-            //tree={this.props.tree}
-            treeNodesCnt={this.props.treeNodesCnt}
-          /> : null
-        ,
-          <Group
-            key={this.props.id}
-            id={this.props.id}
-            isDraggingMe={isDraggingMe}
-            onDragStart={this.props.onDragStart}
-            isRoot={isRoot}
-            allowFurtherNesting={allowFurtherNesting}
-            conjunctionOptions={this.conjunctionOptions}
-            not={this.props.not}
-            selectedConjunction={this.props.conjunction}
-            setConjunction={this.setConjunction}
-            setNot={this.setNot}
-            removeSelf={this.removeSelf}
-            addGroup={this.addGroup}
-            addRule={this.addRule}
-            config={this.props.config}
-            children1={this.props.children1}
-            actions={this.props.actions}
-            //tree={this.props.tree}
-            treeNodesCnt={this.props.treeNodesCnt}
-          />
-        ]}
+          {[
+            isDraggingMe ? <Group
+              key={"dragging"}
+              id={this.props.id}
+              isDraggingMe={isDraggingMe}
+              isDraggingTempo={true}
+              dragging={this.props.dragging}
+              isRoot={isRoot}
+              allowFurtherNesting={allowFurtherNesting}
+              conjunctionOptions={this.conjunctionOptions}
+              not={this.props.not}
+              selectedConjunction={this.props.conjunction}
+              setConjunction={this.dummyFn}
+              setNot={this.dummyFn}
+              removeSelf={this.dummyFn}
+              addGroup={this.dummyFn}
+              addRule={this.dummyFn}
+              config={this.props.config}
+              children1={this.props.children1}
+              actions={this.props.actions}
+              customData={this.props.customData}
+              //tree={this.props.tree}
+              treeNodesCnt={this.props.treeNodesCnt}
+            /> : null
+            ,
+            <Group
+              key={this.props.id}
+              id={this.props.id}
+              isDraggingMe={isDraggingMe}
+              onDragStart={this.props.onDragStart}
+              isRoot={isRoot}
+              allowFurtherNesting={allowFurtherNesting}
+              conjunctionOptions={this.conjunctionOptions}
+              not={this.props.not}
+              selectedConjunction={this.props.conjunction}
+              setConjunction={this.setConjunction}
+              setNot={this.setNot}
+              removeSelf={this.removeSelf}
+              addGroup={this.addGroup}
+              addRule={this.addRule}
+              config={this.props.config}
+              children1={this.props.children1}
+              actions={this.props.actions}
+              customData={this.props.customData}
+              //tree={this.props.tree}
+              treeNodesCnt={this.props.treeNodesCnt}
+            />
+          ]}
         </div>
       );
     }
@@ -170,11 +174,11 @@ export default (Group) => {
   };
 
   const ConnectedGroupContainer = connect(
-      (state) => {
-          return {
-            dragging: state.dragging,
-          }
+    (state) => {
+      return {
+        dragging: state.dragging,
       }
+    }
   )(GroupContainer);
   ConnectedGroupContainer.displayName = "ConnectedGroupContainer";
 

--- a/modules/components/containers/RuleContainer.jsx
+++ b/modules/components/containers/RuleContainer.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {getFieldConfig} from "../../utils/configUtils";
+import { getFieldConfig } from "../../utils/configUtils";
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
 
 export default (Rule) => {
@@ -21,18 +21,20 @@ export default (Rule) => {
       treeNodesCnt: PropTypes.number,
       //connected:
       dragging: PropTypes.object, //{id, x, y, w, h}
+      //custom client data props
+      customData: PropTypes.any,
     };
 
     constructor(props) {
-        super(props);
+      super(props);
 
-        this.componentWillReceiveProps(props);
+      this.componentWillReceiveProps(props);
     }
 
     componentWillReceiveProps(nextProps) {
     }
 
-    dummyFn = () => {}
+    dummyFn = () => { }
 
     removeSelf = () => {
       this.props.actions.removeRule(this.props.path);
@@ -51,40 +53,40 @@ export default (Rule) => {
     }
 
     setValue = (delta, value, type, __isInternal) => {
-        this.props.actions.setValue(this.props.path, delta, value, type, __isInternal);
+      this.props.actions.setValue(this.props.path, delta, value, type, __isInternal);
     }
 
     setValueSrc = (delta, srcKey) => {
-        this.props.actions.setValueSrc(this.props.path, delta, srcKey);
+      this.props.actions.setValueSrc(this.props.path, delta, srcKey);
     }
 
 
     pureShouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
-    
-    shouldComponentUpdate(nextProps, nextState) {
-        let prevProps = this.props;
-        let prevState = this.state;
 
-        let should = this.pureShouldComponentUpdate(nextProps, nextState);
-        if (should) {
-          if (prevState == nextState && prevProps != nextProps) {
-            const draggingId = (nextProps.dragging.id || prevProps.dragging.id);
-            const isDraggingMe = draggingId == nextProps.id;
-            let chs = [];
-            for (let k in nextProps) {
-                let changed = (nextProps[k] != prevProps[k]);
-                if (k == 'dragging' && !isDraggingMe) {
-                  changed = false; //dragging another item -> ignore
-                }
-                if (changed) {
-                  chs.push(k);
-                }
+    shouldComponentUpdate(nextProps, nextState) {
+      let prevProps = this.props;
+      let prevState = this.state;
+
+      let should = this.pureShouldComponentUpdate(nextProps, nextState);
+      if (should) {
+        if (prevState == nextState && prevProps != nextProps) {
+          const draggingId = (nextProps.dragging.id || prevProps.dragging.id);
+          const isDraggingMe = draggingId == nextProps.id;
+          let chs = [];
+          for (let k in nextProps) {
+            let changed = (nextProps[k] != prevProps[k]);
+            if (k == 'dragging' && !isDraggingMe) {
+              changed = false; //dragging another item -> ignore
             }
-            if (!chs.length)
-                should = false;
+            if (changed) {
+              chs.push(k);
+            }
           }
+          if (!chs.length)
+            should = false;
         }
-        return should;
+      }
+      return should;
     }
 
     render() {
@@ -97,46 +99,48 @@ export default (Rule) => {
           className={'group-or-rule-container rule-container'}
           data-id={this.props.id}
         >
-        {[
-          isDraggingMe ? <Rule
-            key={"dragging"}
-            id={this.props.id}
-            isDraggingMe={isDraggingMe}
-            isDraggingTempo={true}
-            dragging={this.props.dragging}
-            setField={this.dummyFn}
-            setOperator={this.dummyFn}
-            setOperatorOption={this.dummyFn}
-            removeSelf={this.dummyFn}
-            selectedField={this.props.field || null}
-            selectedOperator={this.props.operator || null}
-            value={this.props.value || null}
-            valueSrc={this.props.valueSrc || null}
-            operatorOptions={this.props.operatorOptions}
-            config={this.props.config}
-            treeNodesCnt={this.props.treeNodesCnt}
-          /> : null
-        ,
-          <Rule
-            key={this.props.id}
-            id={this.props.id}
-            isDraggingMe={isDraggingMe}
-            onDragStart={this.props.onDragStart}
-            removeSelf={this.removeSelf}
-            setField={this.setField}
-            setOperator={this.setOperator}
-            setOperatorOption={this.setOperatorOption}
-            setValue={this.setValue}
-            setValueSrc={this.setValueSrc}
-            selectedField={this.props.field || null}
-            selectedOperator={this.props.operator || null}
-            value={this.props.value || null}
-            valueSrc={this.props.valueSrc || null}
-            operatorOptions={this.props.operatorOptions}
-            config={this.props.config}
-            treeNodesCnt={this.props.treeNodesCnt}
-          />
-        ]}
+          {[
+            isDraggingMe ? <Rule
+              key={"dragging"}
+              id={this.props.id}
+              isDraggingMe={isDraggingMe}
+              isDraggingTempo={true}
+              dragging={this.props.dragging}
+              setField={this.dummyFn}
+              setOperator={this.dummyFn}
+              setOperatorOption={this.dummyFn}
+              removeSelf={this.dummyFn}
+              selectedField={this.props.field || null}
+              selectedOperator={this.props.operator || null}
+              value={this.props.value || null}
+              valueSrc={this.props.valueSrc || null}
+              operatorOptions={this.props.operatorOptions}
+              config={this.props.config}
+              treeNodesCnt={this.props.treeNodesCnt}
+              customData={this.props.customData}
+            /> : null
+            ,
+            <Rule
+              key={this.props.id}
+              id={this.props.id}
+              isDraggingMe={isDraggingMe}
+              onDragStart={this.props.onDragStart}
+              removeSelf={this.removeSelf}
+              setField={this.setField}
+              setOperator={this.setOperator}
+              setOperatorOption={this.setOperatorOption}
+              setValue={this.setValue}
+              setValueSrc={this.setValueSrc}
+              selectedField={this.props.field || null}
+              selectedOperator={this.props.operator || null}
+              value={this.props.value || null}
+              valueSrc={this.props.valueSrc || null}
+              operatorOptions={this.props.operatorOptions}
+              config={this.props.config}
+              treeNodesCnt={this.props.treeNodesCnt}
+              customData={this.props.customData}
+            />
+          ]}
         </div>
       );
     }
@@ -145,11 +149,11 @@ export default (Rule) => {
 
 
   const ConnectedRuleContainer = connect(
-      (state) => {
-          return {
-            dragging: state.dragging,
-          }
+    (state) => {
+      return {
+        dragging: state.dragging,
       }
+    }
   )(RuleContainer);
   ConnectedRuleContainer.displayName = "ConnectedRuleContainer";
 

--- a/modules/config/default.js
+++ b/modules/config/default.js
@@ -1,5 +1,6 @@
 import en_US from 'antd/lib/locale-provider/en_US';
 import * as Widgets from '../components/widgets';
+import RuleResult from '../components/RuleResult';
 import React from "react";
 const {
   FieldSelect,
@@ -11,9 +12,9 @@ const {
 export const settings = {
   formatField: (field, parts, label2, fieldDefinition, config, isForDisplay) => {
     if (isForDisplay)
-        return label2;
+      return label2;
     else
-        return field;
+      return field;
   },
 
   renderField: (props) => <FieldSelect {...props} />,
@@ -26,9 +27,10 @@ export const settings = {
   // renderOperator: (props) => <VanillaFieldSelect {...props} />,
 
   renderFunc: (props) => <FieldSelect {...props} />,
+  renderResult: (props) => <RuleResult {...props} emptyValue={"?"} />,
 
   valueSourcesInfo: {
-      value: {},
+    value: {},
   },
   fieldSeparator: '.',
   fieldSeparatorDisplay: '.',
@@ -63,4 +65,7 @@ export const settings = {
   valueSourcesPopupTitle: "Select value source",
   removeRuleConfirmOptions: null,
   removeGroupConfirmOptions: null,
+
+  showRuleResults: true,
+  showGroupResults: true,
 };

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -1,6 +1,6 @@
 
-import {List as ImmutableList, Map as ImmutableMap} from 'immutable';
-import {ElementType, ReactElement, Factory} from 'react';
+import { List as ImmutableList, Map as ImmutableMap, OrderedMap } from 'immutable';
+import { ElementType, ReactElement, Factory } from 'react';
 
 
 ////////////////
@@ -33,7 +33,7 @@ type ValueSource = "value" | "field" | "func" | "const";
 type JsonGroup = {
   type: "group",
   id?: String,
-  children1?: {[id: string]: JsonGroup|JsonRule},
+  children1?: { [id: string]: JsonGroup | JsonRule },
   properties?: {
     conjunction: String,
     not?: Boolean,
@@ -50,9 +50,26 @@ type JsonRule = {
     operatorOptions?: {}
   }
 };
+type FlatTreeItem = {
+  type: String,
+  index: Number,
+  id: String,
+  path: String,
+  parent: String,
+  prev: String,
+  next: String,
+  leaf: Boolean,
+  lev: Number,
+  children: OrderedMap,
+};
+type FlatTree = {
+  flat: Array<String>,
+  items: Array<FlatTreeItem>,
+};
+
 export type JsonTree = JsonGroup;
 
-export type ImmutableTree = ImmutableMap<String, String|Object>;
+export type ImmutableTree = ImmutableMap<String, String | Object>;
 
 
 ////////////////
@@ -70,6 +87,7 @@ export interface Utils {
   getTree(tree: ImmutableTree): JsonTree;
   loadTree(tree: JsonTree): ImmutableTree;
   checkTree(tree: ImmutableTree, config: Config): ImmutableTree;
+  getFlatTree(tree: ImmutableTree): FlatTree;
   // other
   uuid(): String;
 };
@@ -77,7 +95,8 @@ export interface Utils {
 export interface BuilderProps {
   tree: ImmutableTree,
   config: Config,
-  actions: {[key: string]: Function},
+  actions: { [key: string]: Function },
+  customData: any,
 };
 
 export interface QueryProps {
@@ -106,15 +125,20 @@ export interface Config {
   funcs?: Funcs,
 };
 
+interface RuleResultProps {
+  ruleId: string,
+  filtered?: number,
+  total?: number,
+};
 
 /////////////////
 // Widgets, WidgetProps
 /////////////////
 
-type FormatValue =         (val: RuleValue, fieldDef: Field, wgtDef: Widget, isForDisplay: Boolean, op: String, opDef: Operator, rightFieldDef?: Field) => string;
-type SqlFormatValue =      (val: RuleValue, fieldDef: Field, wgtDef: Widget, op: String, opDef: Operator, rightFieldDef?: Field) => String;
-type MongoFormatValue =    (val: RuleValue, fieldDef: Field, wgtDef: Widget, op: String, opDef: Operator) => MongoValue;
-type ValidateValue =       (val: RuleValue, fieldDef: Field) => Boolean;
+type FormatValue = (val: RuleValue, fieldDef: Field, wgtDef: Widget, isForDisplay: Boolean, op: String, opDef: Operator, rightFieldDef?: Field) => string;
+type SqlFormatValue = (val: RuleValue, fieldDef: Field, wgtDef: Widget, op: String, opDef: Operator, rightFieldDef?: Field) => String;
+type MongoFormatValue = (val: RuleValue, fieldDef: Field, wgtDef: Widget, op: String, opDef: Operator) => MongoValue;
+type ValidateValue = (val: RuleValue, fieldDef: Field) => Boolean;
 
 interface BaseWidgetProps {
   value: RuleValue,
@@ -154,7 +178,7 @@ export interface BaseWidget {
 };
 export interface RangeableWidget extends BaseWidget {
   singleWidget?: String,
-  valueLabels?: Array<String | {label: String, placeholder: String}>,
+  valueLabels?: Array<String | { label: String, placeholder: String }>,
 };
 export interface FieldWidget {
   customProps?: {},
@@ -172,7 +196,7 @@ export type BooleanWidget = BaseWidget & BooleanFieldSettings;
 export type NumberWidget = RangeableWidget & NumberFieldSettings;
 export type SelectWidget = BaseWidget & SelectFieldSettings;
 
-export type Widget = FieldWidget |  TextWidget | DateTimeWidget | BooleanWidget | NumberWidget | SelectWidget  | RangeableWidget | BaseWidget;
+export type Widget = FieldWidget | TextWidget | DateTimeWidget | BooleanWidget | NumberWidget | SelectWidget | RangeableWidget | BaseWidget;
 export type Widgets = TypedMap<Widget>;
 
 
@@ -209,7 +233,7 @@ interface ProximityConfig {
   minProximity: Number,
   maxProximity: Number,
   defaults: {
-      proximity: Number,
+    proximity: Number,
   },
   customProps?: {},
 };
@@ -244,7 +268,7 @@ interface BinaryOperator extends BaseOperator {
 interface Operator2 extends BaseOperator {
   //cardinality: 2
   textSeparators: Array<String>,
-  valueLabels: Array<String | {label: String, placeholder: String}>,
+  valueLabels: Array<String | { label: String, placeholder: String }>,
   isSpecialRange?: Boolean,
 };
 interface OperatorProximity extends Operator2 {
@@ -285,7 +309,7 @@ interface NumberFieldSettings extends BasicFieldSettings {
   min?: Number,
   max?: Number,
   step?: Number,
-  marks?: {[mark: number]: ReactElement | String}
+  marks?: { [mark: number]: ReactElement | String }
 };
 interface DateTimeFieldSettings extends BasicFieldSettings {
   timeFormat?: String,
@@ -345,12 +369,12 @@ export type Fields = TypedMap<FieldOrGroup>;
 /////////////////
 
 export type FieldItem = {
-  items?: FieldItems, 
-  key: String, 
-  path?: String, 
-  label: String, 
-  fullLabel?: String, 
-  altLabel?: String, 
+  items?: FieldItems,
+  key: String,
+  path?: String,
+  label: String,
+  fullLabel?: String,
+  altLabel?: String,
   tooltip?: String
 };
 type FieldItems = TypedMap<FieldItem>;
@@ -367,7 +391,7 @@ export interface FieldProps {
   config?: Config,
   customProps?: {},
   placeholder?: String,
-  selectedOpts?: {tooltip?: String},
+  selectedOpts?: { tooltip?: String },
 }
 
 
@@ -375,7 +399,7 @@ export interface FieldProps {
 // Settings
 /////////////////
 
-type ValueSourcesInfo = {[vs in ValueSource]?: {label: String, widget?: String}};
+type ValueSourcesInfo = { [vs in ValueSource]?: { label: String, widget?: String } };
 type AntdPosition = "topLeft" | "topCenter" | "topRight" | "bottomLeft" | "bottomCenter" | "bottomRight";
 type AntdSize = "small" | "large" | "medium";
 type ChangeFieldStrategy = "default" | "keep" | "first" | "none";
@@ -404,9 +428,9 @@ export interface LocaleSettings {
   notLabel?: String,
   valueSourcesPopupTitle?: String,
   removeRuleConfirmOptions?: {
-      title?: String,
-      okText?: String,
-      okType?: String,
+    title?: String,
+    okText?: String,
+    okType?: String,
   },
   removeGroupConfirmOptions?: {
     title?: String,

--- a/modules/index.js
+++ b/modules/index.js
@@ -6,8 +6,10 @@ import * as Import from './import';
 import * as Widgets from './components/widgets/index';
 import * as Operators from './components/operators';
 import * as BasicUtils from './utils';
-const Utils = {...BasicUtils, ...Export, ...Import};
-export {Widgets, Operators, Utils, Export, Import};
+import { getFlatTree } from './utils/treeUtils';
 
-export {default as BasicConfig} from './config/basic';
+const Utils = { ...BasicUtils, ...Export, ...Import, getFlatTree };
+export { Widgets, Operators, Utils, Export, Import };
+
+export { default as BasicConfig } from './config/basic';
 


### PR DESCRIPTION
Hi, 

Can you please check the idea & code behind this PR :)
Our intention was to make the querybuilder able to show the actual result/affect of a rule/filter/group queried from the backend.
If you know a better way to solve the issue, or anything to change to be more compliant with the original codebase please let me know.
Also I'm a backend dev., not a css guy, and our frontend team member is in vacation so sorry for the styling part :)

This is a screenshot about how it can look like, just to make it easier to imagine the problem:
![image](https://user-images.githubusercontent.com/12926923/71984208-b1208300-3228-11ea-8e14-337101be828b.png)

Thank You,
Zoltan