### PR TITLE
Added supprt of !group and $elemMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+- 1.3.0
+  - Added support of `!group`
 - 1.2.0
   - Added `treeselect` and `treemultiselect` types
   - Changed format of `listValues` from `{<value>: <title>}` to `[{value, title}]` (old is supported). 

--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -151,8 +151,9 @@ const myConfig = {
 [cols="1m,1,1,5a",options="header"]
 |===
 |key |required |default |meaning
-|type |+ | |One of types described in link:#configtypes[config.types] or `!struct` for complex field
-|subfields |+ for `!struct` type | |Config for subfields of complex field (multiple nesting is supported)
+|type |+ | |One of types described in link:#configtypes[config.types] or `!struct`/`!group` for complex field +
+ (`!group` can be used with https://docs.mongodb.com/manual/reference/operator/query/elemMatch/[elemMatch] in MongoDb)
+|subfields |+ for `!struct`/`!group` type | |Config for subfields of complex field (multiple nesting is supported)
 |label |+ | |Label to be displayed in field list +
   (If not specified, fields's key will be used instead)
 |label2 | | |Can be optionally specified for nested fields. +

--- a/css/compact_styles.scss
+++ b/css/compact_styles.scss
@@ -16,6 +16,9 @@
 .group {
   padding-left: 0px;
 }
+.rule_group {
+  padding-left: 5px;
+}
 
 .group--children {
   @extend %force_nomargin;
@@ -61,6 +64,26 @@
 .rule--operator, .widget--widget, .widget--valuesrc, .widget--sep {
   margin-left: 5px;
 }
+
+.rule_group {
+  .group--actions {
+    margin-left: 5px;
+  }
+  .rule_group--children {
+    padding-left: 10px !important;
+    &.one--child {
+      padding-left: 5px !important;
+    }
+
+    & > .group-or-rule-container > .group-or-rule {
+      &::before, &::after {
+          left: -7px;
+          width: 7px;
+      }
+    }
+  }
+}
+
 .widget--valuesrc {
   margin-right: -3px;
 }
@@ -75,6 +98,9 @@
   margin: 0;
 }
 
+.group--drag-handler {
+  margin-left: 5px;
+}
 
 .rule--func--arg-value > .rule--widget {
   margin-left: -5px;

--- a/css/compact_styles.scss
+++ b/css/compact_styles.scss
@@ -42,8 +42,20 @@
 }
 
 .group-or-rule-container {
-    margin-bottom: 5px;
-    padding-right: 5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  padding-right: 5px;
+}
+.group--children {
+  margin-top: 5px !important;
+  margin-bottom: 5px !important;
+}
+.group--header,
+.group--footer {
+  margin: {
+    top: 5px !important;
+    bottom: 5px !important;
+  }
 }
 
 .rule--operator, .widget--widget, .widget--valuesrc, .widget--sep {
@@ -56,8 +68,11 @@
   margin-right: 5px;
 }
 .group--header {
-  padding: 5px;
-  padding-left: 0;
+  padding: {
+    left: 0;
+    right: 5px;
+  }
+  margin: 0;
 }
 
 

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -159,7 +159,7 @@ ul.ant-select-selection__rendered {
   }
 
 
-  &.rule-group > .group-or-rule-container:first-child > .group-or-rule {
+  &.rule_group--children > .group-or-rule-container:first-child > .group-or-rule {
       &::before {
         display: none;
       }

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -207,6 +207,15 @@ ul.ant-select-selection__rendered {
   cursor: grabbing;
 }
 
+.group--drag-handler {
+  margin-right: 8px;
+}
+.group--conjunctions {
+  .group--drag-handler {
+    margin-left: 10px;
+  }
+}
+
 .group--conjunctions.hide--conj {
     opacity: 0.3;
 }
@@ -240,18 +249,50 @@ ul.ant-select-selection__rendered {
 }
 
 
-.group--drag-handler {
-  margin-left: 8px;
-}
-
 /******************************************************************************/
 /** RULE_GROUP *********************************************************************/
 /******************************************************************************/
 
 .rule_group {
-  
-}
+  display: flex;
+  padding-left: 10px;
 
+  .group--drag-handler {
+    align-self: center;
+  }
+  .group--field {
+    align-self: center;
+  }
+  .group--actions {
+    align-self: center;
+    flex: 0;
+  }
+
+  .rule_group--children {
+    flex: 1;
+
+    margin-top: 5px;
+    margin-bottom: 5px;
+    .group-or-rule-container {
+      margin-bottom: 5px;
+      margin-top: 5px;
+      padding-right: 5px;
+    }
+
+    padding-left: 18px;
+    &.one--child {
+      padding-left: 10px;
+    }
+
+    & > .group-or-rule-container > .group-or-rule {
+      &::before, &::after {
+          left: -10px;
+          width: 10px;
+          height: calc(50% + 8px);
+      }
+    }
+  }
+}
 
 /******************************************************************************/
 /** RULE **********************************************************************/
@@ -276,7 +317,7 @@ ul.ant-select-selection__rendered {
   margin-right: 8px;
 }
 
-.rule--field, .rule--operator, .rule--value, .rule--operator-options, .rule--widget, 
+.rule--field, .group--field, .rule--operator, .rule--value, .rule--operator-options, .rule--widget, 
 .widget--widget, .widget--valuesrc, .widget--sep, .operator--options--sep,
 .rule--before-widget, .rule--after-widget {
   display: inline-block;
@@ -298,7 +339,7 @@ div.tooltip-inner {
   max-width: 500px;
 }
 
-.rule--field, .rule--operator, .widget--widget {
+.rule--field, .group--field, .rule--operator, .widget--widget {
   label {
     display: block;
     font-weight: bold;
@@ -400,7 +441,9 @@ div.tooltip-inner {
     transition: opacity 0.2s;
   }
   .group--header:hover .group--header,
-  .group--header:not(:hover) {
+  .group--header:not(:hover),
+  .rule_group:hover .rule_group,
+  .rule_group:not(:hover) {
     #{$what} {
       opacity: 0;
     }
@@ -412,7 +455,9 @@ div.tooltip-inner {
     transition: padding 0.2s;
   }
   .group--header:hover .group--header,
-  .group--header:not(:hover) {
+  .group--header:not(:hover),
+  .rule_group:hover .rule_group,
+  .rule_group:not(:hover) {
     #{$inactive} {
       width: 0;
       padding: 0;
@@ -490,10 +535,10 @@ $rule_actions: ".widget--valuesrc", ".rule--drag-handler", ".rule--header";
   margin-bottom: 10px;
   padding-right: 10px;
   &:first-child {
-    margin-top: 0px;
+    margin-top: 0px !important;
   }
   &:last-child {
-    margin-bottom: 0px;
+    margin-bottom: 0px !important;
   }
 }
 .group--children {

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -81,6 +81,11 @@ body.qb-dragging {
   position: relative;
 }
 
+.rule_group {
+  background: rgba(255, 252, 242, 0.5);
+  border: 1px solid #f9f1dd;
+}
+
 .qb-draggable {
   @extend %noselect;
   pointer-events: none;
@@ -136,7 +141,7 @@ ul.ant-select-selection__rendered {
 
      &::after {
         top: 50%;
-        border-width: 0 0 0 2px;    
+        border-width: 0 0 0 2px;
     }
 
     &::before, &::after {
@@ -153,6 +158,16 @@ ul.ant-select-selection__rendered {
     }
   }
 
+
+  &.rule-group > .group-or-rule-container:first-child > .group-or-rule {
+      &::before {
+        display: none;
+      }
+      &::after {
+        border-radius: 4px 0 0 0;
+        border-width: 2 0 0 2px;
+      }
+  }
 
   & > .group-or-rule-container:first-child > .group-or-rule {
       &::before {
@@ -228,6 +243,15 @@ ul.ant-select-selection__rendered {
 .group--drag-handler {
   margin-left: 8px;
 }
+
+/******************************************************************************/
+/** RULE_GROUP *********************************************************************/
+/******************************************************************************/
+
+.rule_group {
+  
+}
+
 
 /******************************************************************************/
 /** RULE **********************************************************************/

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -93,11 +93,6 @@ body.qb-dragging {
     border: 1px dashed gray;
 }
 
-.group-or-rule-container {
-    margin-bottom: 10px;
-    padding-right: 10px;
-}
-
 /* slider */
 .ant-tooltip-inner {
   min-height: 18px;
@@ -195,16 +190,6 @@ ul.ant-select-selection__rendered {
   @extend %noselect;
   cursor: -webkit-grabbing;
   cursor: grabbing;
-}
-
-.group--header,
-.group--footer {
-  padding: {
-    top: 10px;
-    right: 5px;
-    bottom: 10px;
-    left: 10px;
-  }
 }
 
 .group--conjunctions.hide--conj {
@@ -456,4 +441,38 @@ $rule_actions: ".widget--valuesrc", ".rule--drag-handler", ".rule--header";
     @include force_unvisible(#{$rule_actions, $group_actions});
     @include force_not_display($inactive_conjs);
   }
+}
+
+
+
+/******************************************************************************/
+/** Vertical padding ****************************************************************/
+/******************************************************************************/
+
+
+.group--header,
+.group--footer {
+  padding: {
+    left: 10px;
+    right: 5px;
+  }
+  margin: {
+    top: 10px;
+    bottom: 10px;
+  }
+}
+.group-or-rule-container {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding-right: 10px;
+  &:first-child {
+    margin-top: 0px;
+  }
+  &:last-child {
+    margin-bottom: 0px;
+  }
+}
+.group--children {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -227,8 +227,7 @@ const fields: Fields = {
         label: 'Group',
         type: '!group',
         subfields: {
-            sub1: {
-                label: 'sub1',
+            sub: {
                 type: 'text',
             }
         }

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -223,12 +223,22 @@ const fields: Fields = {
             }
         }
     },
-    group: {
-        label: 'Group',
+    results: {
+        label: 'Results',
         type: '!group',
         subfields: {
-            sub: {
-                type: 'text',
+            product: {
+                type: 'select',
+                listValues: ['abc', 'def', 'xyz'],
+                valueSources: ['value'],
+            },
+            score: {
+                type: 'number',
+                fieldSettings: {
+                    min: 0,
+                    max: 100
+                },
+                valueSources: ['value'],
             }
         }
     },

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -223,6 +223,16 @@ const fields: Fields = {
             }
         }
     },
+    group: {
+        label: 'Group',
+        type: '!group',
+        subfields: {
+            sub1: {
+                label: 'sub1',
+                type: 'text',
+            }
+        }
+    },
     prox1: {
         label: 'prox',
         tooltip: 'Proximity search',

--- a/examples/demo/init_value.js
+++ b/examples/demo/init_value.js
@@ -58,6 +58,47 @@ export default
           "number"
         ]
       }
+    },
+    "aaab8999-cdef-4012-b456-71702cd50090": {
+      "type": "rule_group",
+      "properties": {
+        "conjunction": "AND",
+        "field": "results"
+      },
+      "children1": {
+        "99b8a8a8-89ab-4cde-b012-31702cd5078b": {
+          "type": "rule",
+          "properties": {
+            "field": "results.product",
+            "operator": "select_equals",
+            "value": [
+              "abc"
+            ],
+            "valueSrc": [
+              "value"
+            ],
+            "valueType": [
+              "select"
+            ]
+          }
+        },
+        "88b9bb89-4567-489a-bcde-f1702cd53266": {
+          "type": "rule",
+          "properties": {
+            "field": "results.score",
+            "operator": "greater",
+            "value": [
+              8
+            ],
+            "valueSrc": [
+              "value"
+            ],
+            "valueType": [
+              "number"
+            ]
+          }
+        }
+      }
     }
   },
   "properties": {

--- a/modules/components/Actions.jsx
+++ b/modules/components/Actions.jsx
@@ -15,7 +15,7 @@ const defaultPosition = 'topRight';
 
 export class Actions extends PureComponent {
   render() {
-    const {config: {settings}, addRule, addGroup, allowFurtherNesting, isRoot, removeSelf} = this.props;
+    const {config: {settings}, addRule, addGroup, isRoot, canAddGroup, removeSelf} = this.props;
     const {immutableGroupsMode, addRuleLabel, addGroupLabel, delGroupLabel, renderSize, groupActionsPosition} = settings;
     const position = groupActionsPositionList[groupActionsPosition || defaultPosition];
 
@@ -26,7 +26,7 @@ export class Actions extends PureComponent {
         className="action action--ADD-RULE"
         onClick={addRule}
       >{addRuleLabel}</Button>;
-    const addGroupBtn = !immutableGroupsMode && allowFurtherNesting &&
+    const addGroupBtn = !immutableGroupsMode && canAddGroup &&
       <Button
         key="group-add-group"
         className="action action--ADD-GROUP"

--- a/modules/components/FuncSelect.jsx
+++ b/modules/components/FuncSelect.jsx
@@ -23,7 +23,7 @@ export default class FuncSelect extends PureComponent {
   constructor(props) {
       super(props);
       useOnPropsChanged(this);
-
+      
       this.onPropsChanged(props);
   }
 

--- a/modules/components/Group.jsx
+++ b/modules/components/Group.jsx
@@ -71,7 +71,7 @@ export class Group extends PureComponent {
   }
 
   isEmpty(item) {
-    return item.get("type") == "group" ? this.isEmptyGroup(item) : this.isEmptyRule(item);
+    return (item.get("type") == "group" || item.get("type") == "rule_group") ? this.isEmptyGroup(item) : this.isEmptyRule(item);
   }
 
   isEmptyGroup(group) {

--- a/modules/components/Group.jsx
+++ b/modules/components/Group.jsx
@@ -102,6 +102,7 @@ export class Group extends PureComponent {
       <div key="group-children" className={classNames(
         "group--children",
         this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : '',
+        this.props.children1.size < 2 ? 'one--child' : '',
         this.childrenClassName()
       )}>{this.renderChildren()}</div>
     );
@@ -202,7 +203,6 @@ export class Group extends PureComponent {
 
   reordableNodesCnt() {
     const {treeNodesCnt} = this.props;
-    console.log(1, treeNodesCnt)
     return treeNodesCnt;
   }
 

--- a/modules/components/Group.jsx
+++ b/modules/components/Group.jsx
@@ -8,7 +8,7 @@ const { confirm } = Modal;
 const classNames = require('classnames');
 import Item from './Item';
 import {ConjsRadios, ConjsButtons} from './Conjs';
-import {Actions} from './Actions';
+import {GroupActions} from './GroupActions';
 
 const defaultPosition = 'topRight';
 
@@ -149,19 +149,22 @@ export class Group extends PureComponent {
   }
 
   renderActions() {
-    const {isRoot, config, addRule, addGroup} = this.props;
+    const {config, addRule, addGroup} = this.props;
 
-    return <Actions
+    return <GroupActions
       config={config}
       addRule={addRule}
       addGroup={addGroup}
-      isRoot={isRoot}
       canAddGroup={this.canAddGroup()}
+      canAddRule={this.canAddRule()}
+      canDeleteGroup={this.canDeleteGroup()}
       removeSelf={this.removeSelf}
     />;
   }
 
   canAddGroup = () => this.props.allowFurtherNesting;
+  canAddRule = () => true;
+  canDeleteGroup = () => !this.props.isRoot;
 
   renderChildren() {
     const {children1} = this.props;
@@ -170,12 +173,13 @@ export class Group extends PureComponent {
 
   renderItem(item) {
     const props = this.props;
-    const {config, actions, onDragStart, treeNodesCnt, children1} = props;
+    const {config, actions, onDragStart} = props;
     const isRuleGroup = item.get('type') == 'group' && item.getIn(['properties', 'field']) != null;
     const type = isRuleGroup ? 'rule_group' : item.get('type');
-
+    
     return (
       <Item
+        {...this.extraPropsForItem(item)}
         key={item.get('id')}
         id={item.get('id')}
         //path={props.path.push(item.get('id'))}
@@ -192,8 +196,13 @@ export class Group extends PureComponent {
     );
   };
 
+  extraPropsForItem(_item) {
+    return {};
+  }
+
   reordableNodesCnt() {
     const {treeNodesCnt} = this.props;
+    console.log(1, treeNodesCnt)
     return treeNodesCnt;
   }
 

--- a/modules/components/Group.jsx
+++ b/modules/components/Group.jsx
@@ -13,9 +13,7 @@ import {Actions} from './Actions';
 const defaultPosition = 'topRight';
 
 
-@GroupContainer
-@Draggable("group")
-class Group extends PureComponent {
+export class Group extends PureComponent {
   static propTypes = {
     //tree: PropTypes.instanceOf(Immutable.Map).isRequired,
     treeNodesCnt: PropTypes.number,
@@ -41,11 +39,17 @@ class Group extends PureComponent {
     actions: PropTypes.object.isRequired,
   };
 
-  isGroupTopPosition = () => {
+  constructor(props) {
+    super(props);
+
+    this.removeSelf = this.removeSelf.bind(this);
+  }
+
+  isGroupTopPosition() {
     return startsWith(this.props.config.settings.groupActionsPosition || defaultPosition, 'top')
   }
 
-  removeSelf = () => {
+  removeSelf() {
     const confirmOptions = this.props.config.settings.removeGroupConfirmOptions;
     const doRemove = () => {
       this.props.removeSelf();
@@ -60,23 +64,23 @@ class Group extends PureComponent {
     }
   }
 
-  isEmptyCurrentGroup = () => {
+  isEmptyCurrentGroup() {
     const children = this.props.children1;
     return children.size == 0 ||
       children.size == 1 && this.isEmpty(children.first());
   }
 
-  isEmpty = (item) => {
+  isEmpty(item) {
     return item.get("type") == "group" ? this.isEmptyGroup(item) : this.isEmptyRule(item);
   }
 
-  isEmptyGroup = (group) => {
+  isEmptyGroup(group) {
     const children = group.get("children1");
     return children.size == 0 ||
       children.size == 1 && this.isEmpty(children.first());
   }
 
-  isEmptyRule = (rule) => {
+  isEmptyRule(rule) {
     const properties = rule.get('properties');
       return !(
           properties.get("field") !== null &&
@@ -86,26 +90,46 @@ class Group extends PureComponent {
   }
 
   render() {
+    return <>
+      {this.renderHeaderWrapper()}
+      {this.renderChildrenWrapper()}
+      {this.renderFooterWrapper()}
+    </>;
+  }
+
+  renderChildrenWrapper() {
+    return this.props.children1 && (
+      <div key="group-children" className={classNames(
+        "group--children",
+        this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : '',
+        this.childrenClassName()
+      )}>{this.renderChildren()}</div>
+    );
+  }
+
+  childrenClassName = () => '';
+
+  renderHeaderWrapper() {
     const isGroupTopPosition = this.isGroupTopPosition();
-    return [
-        <div key="group-header" className="group--header">
-          {this.renderHeader()}
-          {isGroupTopPosition && this.renderBeforeActions()}
-          {isGroupTopPosition && this.renderActions()}
-          {isGroupTopPosition && this.renderAfterActions()}
-        </div>
-    , this.props.children1 &&
-        <div key="group-children" className={classNames(
-          "group--children",
-          this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--line' : ''
-        )}>{this.renderChildren()}</div>
-    , !isGroupTopPosition &&
-        <div key="group-footer" className='group--footer'>
-          {this.renderBeforeActions()}
-          {this.renderActions()}
-          {this.renderAfterActions()}
-        </div>
-    ];
+    return (
+      <div key="group-header" className="group--header">
+       {this.renderHeader()}
+       {isGroupTopPosition && this.renderBeforeActions()}
+       {isGroupTopPosition && this.renderActions()}
+       {isGroupTopPosition && this.renderAfterActions()}
+     </div>
+    );
+  }
+
+  renderFooterWrapper() {
+    const isGroupTopPosition = this.isGroupTopPosition();
+    return !isGroupTopPosition && (
+      <div key="group-footer" className='group--footer'>
+        {this.renderBeforeActions()}
+        {this.renderActions()}
+        {this.renderAfterActions()}
+      </div>
+    );
   }
 
   renderBeforeActions = () => {
@@ -124,69 +148,101 @@ class Group extends PureComponent {
     return typeof AfterActions === 'function' ? <AfterActions {...this.props}/> : AfterActions;
   }
 
-  renderActions = () => {
+  renderActions() {
+    const {isRoot, config, addRule, addGroup} = this.props;
+
     return <Actions
-      config={this.props.config}
-      addRule={this.props.addRule}
-      addGroup={this.props.addGroup}
-      allowFurtherNesting={this.props.allowFurtherNesting}
-      isRoot={this.props.isRoot}
+      config={config}
+      addRule={addRule}
+      addGroup={addGroup}
+      isRoot={isRoot}
+      canAddGroup={this.canAddGroup()}
       removeSelf={this.removeSelf}
     />;
   }
 
-  renderChildren = () => {
+  canAddGroup = () => this.props.allowFurtherNesting;
+
+  renderChildren() {
+    const {children1} = this.props;
+    return children1 ? children1.map(this.renderItem.bind(this)).toList() : null;
+  }
+
+  renderItem(item) {
     const props = this.props;
-    return props.children1 ? props.children1.map((item) => (
+    const {config, actions, onDragStart, treeNodesCnt, children1} = props;
+    const isRuleGroup = item.get('type') == 'group' && item.getIn(['properties', 'field']) != null;
+    const type = isRuleGroup ? 'rule_group' : item.get('type');
+
+    return (
       <Item
         key={item.get('id')}
         id={item.get('id')}
         //path={props.path.push(item.get('id'))}
         path={item.get('path')}
-        type={item.get('type')}
+        type={type}
         properties={item.get('properties')}
-        config={props.config}
-        actions={props.actions}
+        config={config}
+        actions={actions}
         children1={item.get('children1')}
         //tree={props.tree}
-        treeNodesCnt={props.treeNodesCnt}
-        onDragStart={props.onDragStart}
+        treeNodesCnt={this.reordableNodesCnt()}
+        onDragStart={onDragStart}
       />
-    )).toList() : null;
+    );
+  };
+
+  reordableNodesCnt() {
+    const {treeNodesCnt} = this.props;
+    return treeNodesCnt;
   }
 
-  renderHeader = () => {
-    const Conjs = this.props.config.settings.renderConjsAsRadios ? ConjsRadios : ConjsButtons;
-
-    const conjs = <Conjs
-      disabled={this.props.children1.size < 2}
-      selectedConjunction={this.props.selectedConjunction}
-      setConjunction={this.props.setConjunction}
-      conjunctionOptions={this.props.conjunctionOptions}
-      config={this.props.config}
-      not={this.props.not}
-      setNot={this.props.setNot}
-    />;
-
-    const showDragIcon = this.props.config.settings.canReorder && this.props.treeNodesCnt > 2 && !this.props.isRoot;
+  renderDrag() {
+    const {
+      config, isRoot, treeNodesCnt,
+      handleDraggerMouseDown
+    } = this.props;
+    const reordableNodesCnt = treeNodesCnt;
+    const showDragIcon = config.settings.canReorder && !isRoot && reordableNodesCnt > 1;
     const drag = showDragIcon &&
       <span
         key="group-drag-icon"
         className={"qb-drag-handler group--drag-handler"}
-        onMouseDown={this.props.handleDraggerMouseDown}
+        onMouseDown={handleDraggerMouseDown}
       ><Icon type="bars" /> </span>;
+    return drag;
+  }
 
+  renderConjs() {
+    const {
+      config, children1,
+      selectedConjunction, setConjunction, conjunctionOptions, not, setNot
+    } = this.props;
+
+    const Conjs = config.settings.renderConjsAsRadios ? ConjsRadios : ConjsButtons;
+    const conjs = <Conjs
+      disabled={children1.size < 2}
+      selectedConjunction={selectedConjunction}
+      setConjunction={setConjunction}
+      conjunctionOptions={conjunctionOptions}
+      config={config}
+      not={not}
+      setNot={setNot}
+    />;
+    return conjs;
+  }
+
+  renderHeader() {
     return (
       <div className={classNames(
         "group--conjunctions",
-        // this.props.children1.size < 2 && this.props.config.settings.hideConjForOne ? 'hide--conj' : ''
+        // children1.size < 2 && config.settings.hideConjForOne ? 'hide--conj' : ''
       )}>
-        {conjs}
-        {drag}
+        {this.renderConjs()}
+        {this.renderDrag()}
       </div>
     );
   }
 }
 
-
-export default Group;
+export default GroupContainer(Draggable("group")(Group));

--- a/modules/components/GroupActions.jsx
+++ b/modules/components/GroupActions.jsx
@@ -13,13 +13,13 @@ const groupActionsPositionList = {
 const defaultPosition = 'topRight';
 
 
-export class Actions extends PureComponent {
+export class GroupActions extends PureComponent {
   render() {
-    const {config: {settings}, addRule, addGroup, isRoot, canAddGroup, removeSelf} = this.props;
+    const {config: {settings}, addRule, addGroup, canAddGroup, canAddRule, canDeleteGroup, removeSelf} = this.props;
     const {immutableGroupsMode, addRuleLabel, addGroupLabel, delGroupLabel, renderSize, groupActionsPosition} = settings;
     const position = groupActionsPositionList[groupActionsPosition || defaultPosition];
 
-    const addRuleBtn = !immutableGroupsMode &&
+    const addRuleBtn = !immutableGroupsMode && canAddRule &&
       <Button
         key="group-add-rule"
         icon="plus"
@@ -33,7 +33,7 @@ export class Actions extends PureComponent {
         icon="plus-circle-o"
         onClick={addGroup}
       >{addGroupLabel}</Button>;
-    const delGroupBtn = !immutableGroupsMode && !isRoot &&
+    const delGroupBtn = !immutableGroupsMode && canDeleteGroup &&
       <Button
         key="group-del"
         type="danger"

--- a/modules/components/Item.jsx
+++ b/modules/components/Item.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Rule from './Rule';
 import Group from './Group';
+import RuleGroup from './RuleGroup';
 
 
 const typeMap = {
@@ -18,6 +19,19 @@ const typeMap = {
   ),
   group: (props) => (
     <Group 
+      {...props.properties.toObject()}
+      id={props.id}
+      path={props.path}
+      actions={props.actions}
+      config={props.config}
+      //tree={props.tree}
+      treeNodesCnt={props.treeNodesCnt}
+      onDragStart={props.onDragStart}
+      children1={props.children1}
+    />
+  ),
+  rule_group: (props) => (
+    <RuleGroup 
       {...props.properties.toObject()}
       id={props.id}
       path={props.path}

--- a/modules/components/Item.jsx
+++ b/modules/components/Item.jsx
@@ -15,6 +15,7 @@ const typeMap = {
       treeNodesCnt={props.treeNodesCnt}
       config={props.config}
       onDragStart={props.onDragStart}
+      parentField={props.parentField}
     />
   ),
   group: (props) => (
@@ -28,6 +29,7 @@ const typeMap = {
       treeNodesCnt={props.treeNodesCnt}
       onDragStart={props.onDragStart}
       children1={props.children1}
+      parentField={null}
     />
   ),
   rule_group: (props) => (
@@ -41,6 +43,7 @@ const typeMap = {
       treeNodesCnt={props.treeNodesCnt}
       onDragStart={props.onDragStart}
       children1={props.children1}
+      parentField={props.parentField}
     />
   )
 };
@@ -58,6 +61,7 @@ class Item extends PureComponent {
     actions: PropTypes.object.isRequired,
     treeNodesCnt: PropTypes.number,
     onDragStart: PropTypes.func,
+    parentField: PropTypes.string, //from RuleGroup
   };
 
   render() {

--- a/modules/components/Rule.jsx
+++ b/modules/components/Rule.jsx
@@ -64,7 +64,7 @@ class Rule extends PureComponent {
         const isOnlyValue = selectedField && selectedFieldConfig.valueSources.length == 1 && selectedFieldConfig.valueSources[0] == 'value';
         const hideOperator = selectedFieldWidgetConfig.hideOperator && isOnlyValue;
 
-        const showDragIcon = config.settings.canReorder && treeNodesCnt > 2;
+        const showDragIcon = config.settings.canReorder && treeNodesCnt > 1;
         const showOperator = selectedField && !hideOperator;
         const showOperatorLabel = selectedField && hideOperator && selectedFieldWidgetConfig.operatorInlineLabel;
         const showWidget = isFieldAndOpSelected;

--- a/modules/components/Rule.jsx
+++ b/modules/components/Rule.jsx
@@ -24,6 +24,7 @@ class Rule extends PureComponent {
         valueSrc: PropTypes.any,
         isDraggingMe: PropTypes.bool,
         isDraggingTempo: PropTypes.bool,
+        parentField: PropTypes.string, //from RuleGroup
         //path: PropTypes.instanceOf(Immutable.List),
         //actions
         handleDraggerMouseDown: PropTypes.func,
@@ -112,6 +113,7 @@ class Rule extends PureComponent {
                 config={this.props.config}
                 selectedField={this.props.selectedField}
                 setField={this.props.setField}
+                parentField={this.props.parentField}
             />;
         const operator = 
             <OperatorWrapper
@@ -205,9 +207,9 @@ class Rule extends PureComponent {
 }
 
 
-class FieldWrapper extends PureComponent {
+export class FieldWrapper extends PureComponent {
     render() {
-        const {config, selectedField, setField} = this.props;
+        const {config, selectedField, setField, parentField} = this.props;
         return (
             <Col className="rule--field">
                 { config.settings.showLabels &&
@@ -216,6 +218,7 @@ class FieldWrapper extends PureComponent {
                 <Field
                     config={config}
                     selectedField={selectedField}
+                    parentField={parentField}
                     setField={setField}
                     customProps={config.settings.customFieldSelectProps}
                 />

--- a/modules/components/Rule.jsx
+++ b/modules/components/Rule.jsx
@@ -110,6 +110,7 @@ class Rule extends PureComponent {
         const field = 
             <FieldWrapper
                 key="field"
+                classname={"rule--field"}
                 config={this.props.config}
                 selectedField={this.props.selectedField}
                 setField={this.props.setField}
@@ -209,9 +210,9 @@ class Rule extends PureComponent {
 
 export class FieldWrapper extends PureComponent {
     render() {
-        const {config, selectedField, setField, parentField} = this.props;
+        const {config, selectedField, setField, parentField, classname} = this.props;
         return (
-            <Col className="rule--field">
+            <Col className={classname}>
                 { config.settings.showLabels &&
                     <label>{config.settings.fieldLabel}</label>
                 }

--- a/modules/components/RuleGroup.jsx
+++ b/modules/components/RuleGroup.jsx
@@ -43,18 +43,19 @@ class RuleGroup extends Group {
 
   renderChildrenWrapper() {
     return (
-      <div>
+      <>
         {this.renderDrag()}
         {this.renderField()}
         {this.renderActions()}
         {super.renderChildrenWrapper()}
-      </div>
+      </>
     );
   }
 
   renderField() {
     return <FieldWrapper
       key="field"
+      classname={"group--field"}
       config={this.props.config}
       selectedField={this.props.selectedField}
       setField={this.props.setField}

--- a/modules/components/RuleGroup.jsx
+++ b/modules/components/RuleGroup.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import GroupContainer from './containers/GroupContainer';
+import Draggable from './containers/Draggable';
+import {Group} from './Group';
+
+
+@GroupContainer
+@Draggable("group rule_group")
+class RuleGroup extends Group {
+  static propTypes = {
+    ...Group.propTypes,
+    selectedField: PropTypes.string, // for RuleGroup
+  };
+
+  childrenClassName = () => 'rule-group';
+  
+  renderHeaderWrapper = () => null;
+  renderFooterWrapper = () => null;
+  renderConjs = () => null;
+  canAddGroup = () => false;
+
+  reordableNodesCnt() {
+    const {children1} = this.props;
+    return children1.size;
+  }
+
+  renderChildrenWrapper() {
+    return (
+      <div>
+        {this.renderDrag()}
+        {this.renderActions()}
+        {super.renderChildrenWrapper()}
+      </div>
+    );
+  };
+}
+
+
+export default RuleGroup;

--- a/modules/components/RuleGroup.jsx
+++ b/modules/components/RuleGroup.jsx
@@ -13,7 +13,7 @@ class RuleGroup extends Group {
     selectedField: PropTypes.string, // for RuleGroup
   };
 
-  childrenClassName = () => 'rule-group';
+  childrenClassName = () => 'rule_group--children';
   
   renderHeaderWrapper = () => null;
   renderFooterWrapper = () => null;

--- a/modules/components/RuleGroup.jsx
+++ b/modules/components/RuleGroup.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import GroupContainer from './containers/GroupContainer';
 import Draggable from './containers/Draggable';
 import {Group} from './Group';
+import {RuleGroupActions} from './RuleGroupActions';
+import {FieldWrapper} from './Rule';
+import {useOnPropsChanged} from "../utils/stuff";
 
 
 @GroupContainer
@@ -10,8 +13,19 @@ import {Group} from './Group';
 class RuleGroup extends Group {
   static propTypes = {
     ...Group.propTypes,
-    selectedField: PropTypes.string, // for RuleGroup
+    selectedField: PropTypes.string,
+    parentField: PropTypes.string,
+    setField: PropTypes.func,
   };
+
+  constructor(props) {
+      super(props);
+      useOnPropsChanged(this);
+      this.onPropsChanged(props);
+  }
+
+  onPropsChanged(nextProps) {
+  }
 
   childrenClassName = () => 'rule_group--children';
   
@@ -19,6 +33,8 @@ class RuleGroup extends Group {
   renderFooterWrapper = () => null;
   renderConjs = () => null;
   canAddGroup = () => false;
+  canAddRule = () => true;
+  canDeleteGroup = () => false;
 
   reordableNodesCnt() {
     const {children1} = this.props;
@@ -29,11 +45,40 @@ class RuleGroup extends Group {
     return (
       <div>
         {this.renderDrag()}
+        {this.renderField()}
         {this.renderActions()}
         {super.renderChildrenWrapper()}
       </div>
     );
-  };
+  }
+
+  renderField() {
+    return <FieldWrapper
+      key="field"
+      config={this.props.config}
+      selectedField={this.props.selectedField}
+      setField={this.props.setField}
+      parentField={this.props.parentField}
+    />;
+  }
+
+  renderActions() {
+    const {config, addRule} = this.props;
+
+    return <RuleGroupActions
+      config={config}
+      addRule={addRule}
+      canAddRule={this.canAddRule()}
+      canDeleteGroup={this.canDeleteGroup()}
+      removeSelf={this.removeSelf}
+    />;
+  }
+
+  extraPropsForItem(_item) {
+    return {
+      parentField: this.props.selectedField
+    };
+  }
 }
 
 

--- a/modules/components/RuleGroupActions.jsx
+++ b/modules/components/RuleGroupActions.jsx
@@ -1,0 +1,37 @@
+import React, { PureComponent } from 'react';
+import { Button } from 'antd';
+
+
+export class RuleGroupActions extends PureComponent {
+  render() {
+    const {config: {settings}, addRule, canAddRule, canDeleteGroup, removeSelf} = this.props;
+    const {immutableGroupsMode, addRuleLabel, delGroupLabel, renderSize} = settings;
+    const _addRuleLabel = "";
+
+    const addRuleBtn = !immutableGroupsMode && canAddRule &&
+      <Button
+        key="group-add-rule"
+        icon="plus"
+        className="action action--ADD-RULE"
+        onClick={addRule}
+        size={renderSize}
+      >{_addRuleLabel}</Button>;
+      
+    const delGroupBtn = !immutableGroupsMode && canDeleteGroup &&
+      <Button
+        key="group-del"
+        type="danger"
+        icon="delete"
+        className="action action--DELETE"
+        size={renderSize}
+        onClick={removeSelf}
+      >{delGroupLabel}</Button>;
+
+    return (
+      <div className={`group--actions`}>
+        {addRuleBtn}
+        {/*delGroupBtn*/}
+      </div>
+    )
+  }
+}

--- a/modules/components/ValueField.jsx
+++ b/modules/components/ValueField.jsx
@@ -98,7 +98,7 @@ export default class ValueField extends PureComponent {
         let subpath = (path ? path : []).concat(rightFieldKey);
         let rightFieldFullkey = subpath.join(fieldSeparator);
         let rightFieldConfig = getFieldConfig(rightFieldFullkey, config);
-        if (rightFieldConfig.type == "!struct") {
+        if (rightFieldConfig.type == "!struct" || rightFieldConfig.type == "!group") {
           if(_filter(subfields, subpath) == 0)
             delete list[rightFieldKey];
         } else {
@@ -138,7 +138,7 @@ export default class ValueField extends PureComponent {
         if (field.hideForCompare)
             return undefined;
 
-        if (field.type == "!struct") {
+        if (field.type == "!struct" || field.type == "!group") {
             return {
                 key: fieldKey,
                 path: prefix+fieldKey,

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -19,6 +19,7 @@ export default (Group) => {
       children1: PropTypes.any, //instanceOf(Immutable.OrderedMap)
       onDragStart: PropTypes.func,
       treeNodesCnt: PropTypes.number,
+      selectedField: PropTypes.string, // for RuleGroup
       //connected:
       dragging: PropTypes.object, //{id, x, y, w, h}
     };
@@ -139,6 +140,7 @@ export default (Group) => {
             actions={this.props.actions}
             //tree={this.props.tree}
             treeNodesCnt={this.props.treeNodesCnt}
+            selectedField={this.props.field || null}
           /> : null
         ,
           <Group
@@ -161,6 +163,7 @@ export default (Group) => {
             actions={this.props.actions}
             //tree={this.props.tree}
             treeNodesCnt={this.props.treeNodesCnt}
+            selectedField={this.props.field || null}
           />
         ]}
         </div>

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -20,6 +20,7 @@ export default (Group) => {
       onDragStart: PropTypes.func,
       treeNodesCnt: PropTypes.number,
       selectedField: PropTypes.string, // for RuleGroup
+      parentField: PropTypes.string, //from RuleGroup
       //connected:
       dragging: PropTypes.object, //{id, x, y, w, h}
     };
@@ -103,6 +104,11 @@ export default (Group) => {
       this.props.actions.addRule(this.props.path);
     }
 
+    // for RuleGroup
+    setField = (field) => {
+      this.props.actions.setField(this.props.path, field);
+    }
+
     render() {
       const isDraggingMe = this.props.dragging.id == this.props.id;
       const currentNesting = this.props.path.size;
@@ -135,12 +141,14 @@ export default (Group) => {
             removeSelf={this.dummyFn}
             addGroup={this.dummyFn}
             addRule={this.dummyFn}
+            setField={this.dummyFn}
             config={this.props.config}
             children1={this.props.children1}
             actions={this.props.actions}
             //tree={this.props.tree}
             treeNodesCnt={this.props.treeNodesCnt}
             selectedField={this.props.field || null}
+            parentField={this.props.parentField || null}
           /> : null
         ,
           <Group
@@ -158,12 +166,14 @@ export default (Group) => {
             removeSelf={this.removeSelf}
             addGroup={this.addGroup}
             addRule={this.addRule}
+            setField={this.setField}
             config={this.props.config}
             children1={this.props.children1}
             actions={this.props.actions}
             //tree={this.props.tree}
             treeNodesCnt={this.props.treeNodesCnt}
             selectedField={this.props.field || null}
+            parentField={this.props.parentField || null}
           />
         ]}
         </div>

--- a/modules/components/containers/RuleContainer.jsx
+++ b/modules/components/containers/RuleContainer.jsx
@@ -19,6 +19,7 @@ export default (Rule) => {
       valueSrc: PropTypes.any,
       operatorOptions: PropTypes.object,
       treeNodesCnt: PropTypes.number,
+      parentField: PropTypes.string, //from RuleGroup
       //connected:
       dragging: PropTypes.object, //{id, x, y, w, h}
     };
@@ -101,6 +102,7 @@ export default (Rule) => {
             setOperatorOption={this.dummyFn}
             removeSelf={this.dummyFn}
             selectedField={this.props.field || null}
+            parentField={this.props.parentField || null}
             selectedOperator={this.props.operator || null}
             value={this.props.value || null}
             valueSrc={this.props.valueSrc || null}
@@ -121,6 +123,7 @@ export default (Rule) => {
             setValue={this.setValue}
             setValueSrc={this.setValueSrc}
             selectedField={this.props.field || null}
+            parentField={this.props.parentField || null}
             selectedOperator={this.props.operator || null}
             value={this.props.value || null}
             valueSrc={this.props.valueSrc || null}

--- a/modules/components/containers/SortableContainer.jsx
+++ b/modules/components/containers/SortableContainer.jsx
@@ -479,11 +479,15 @@ export default (Builder, CanMoveFn = null) => {
         return false;
 
       const canRegroup = this.props.config.settings.canRegroup;
-      const isStructChange = placement == constants.PLACEMENT_PREPEND || placement == constants.PLACEMENT_APPEND
-        || fromII.parent != toII.parent;
-      if (!canRegroup && isStructChange)
+      const isPend = placement == constants.PLACEMENT_PREPEND || placement == constants.PLACEMENT_APPEND;
+      const isParentChange = fromII.parent != toII.parent;
+      const isStructChange = isPend || isParentChange;
+      const isForbiddenStructChange = fromII.parentType == 'rule_group' || toII.type == 'rule_group' 
+        || toII.parentType == 'rule_group';
+      
+      if (isStructChange && (!canRegroup || isForbiddenStructChange))
         return false;
-
+      
       let res = true;
       if (canMoveFn)
         res = canMoveFn(fromII.node.toJS(), toII.node.toJS(), placement, toParentII ? toParentII.node.toJS() : null);

--- a/modules/components/containers/SortableContainer.jsx
+++ b/modules/components/containers/SortableContainer.jsx
@@ -314,14 +314,16 @@ export default (Builder, CanMoveFn = null) => {
                     //take group header (for prepend only)
                     const hovInnerEl = hovCNodeEl.getElementsByClassName('group--header');
                     const hovEl2 = hovInnerEl.length ? hovInnerEl[0] : null;
-                    const hovRect2 = hovEl2.getBoundingClientRect();
-                    const hovHeight2 = hovRect2.bottom - hovRect2.top;
-                    const isOverHover = ((dragRect.bottom - hovRect2.top) > hovHeight2*3/4);
-                    if (isOverHover && hovII.top > dragInfo.itemInfo.top) {
-                      trgII = hovII;
-                      trgRect = hovRect2;
-                      trgEl = hovEl2;
-                      doPrepend = true;
+                    if (hovEl2) {
+                      const hovRect2 = hovEl2.getBoundingClientRect();
+                      const hovHeight2 = hovRect2.bottom - hovRect2.top;
+                      const isOverHover = ((dragRect.bottom - hovRect2.top) > hovHeight2*3/4);
+                      if (isOverHover && hovII.top > dragInfo.itemInfo.top) {
+                        trgII = hovII;
+                        trgRect = hovRect2;
+                        trgEl = hovEl2;
+                        doPrepend = true;
+                      }
                     }
                 } else if (dragDirs.vrt < 0) { //up
                   if (hovII.lev >= itemInfo.lev) {

--- a/modules/export/jsonLogic.js
+++ b/modules/export/jsonLogic.js
@@ -132,7 +132,7 @@ const jsonLogicFormatItem = (item, config, meta) => {
     const properties = item.get('properties') || new Map();
     const children = item.get('children1');
 
-    if (type === 'group' && children && children.size) {
+    if ((type === 'group' || type === 'rule_group') && children && children.size) {
         const list = children
             .map((currentChild) => jsonLogicFormatItem(currentChild, config, meta))
             .filter((currentChild) => typeof currentChild !== 'undefined');

--- a/modules/export/queryBuilder.js
+++ b/modules/export/queryBuilder.js
@@ -61,7 +61,7 @@ const _queryBuilderFormat = (item, config, meta) => {
     const children = item.get('children1');
     const id = item.get('id');
 
-    if (type === 'group' && children && children.size) {
+    if ((type === 'group' || type === 'rule_group') && children && children.size) {
         const list = children
             .map((currentChild) => _queryBuilderFormat(currentChild, config, meta))
             .filter((currentChild) => typeof currentChild !== 'undefined');

--- a/modules/export/queryString.js
+++ b/modules/export/queryString.js
@@ -92,7 +92,7 @@ export const queryString = (item, config, isForDisplay = false) => {
     const properties = item.get('properties') || new Map();
     const children = item.get('children1');
 
-    if (type === 'group' && children && children.size) {
+    if ((type === 'group' || type === 'rule_group') && children && children.size) {
         const not = properties.get('not');
         const list = children
             .map((currentChild) => queryString(currentChild, config, isForDisplay))

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -111,7 +111,7 @@ const sqlFormatItem = (item, config, meta) => {
     const properties = item.get('properties') || new Map();
     const children = item.get('children1');
 
-    if (type === 'group' && children && children.size) {
+    if ((type === 'group' || type === 'rule_group') && children && children.size) {
         const not = properties.get('not');
         const list = children
             .map((currentChild) => sqlFormatItem(currentChild, config, meta))

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -33,10 +33,18 @@ type ValueSource = "value" | "field" | "func" | "const";
 type JsonGroup = {
   type: "group",
   id?: String,
-  children1?: {[id: string]: JsonGroup|JsonRule},
+  children1?: {[id: string]: JsonGroup|JsonRule|JsonRuleGroup},
   properties?: {
     conjunction: String,
     not?: Boolean,
+  }
+};
+type JsonRuleGroup = {
+  type: "rule_group",
+  id?: String,
+  children1?: {[id: string]: JsonRuleGroup|JsonRule},
+  properties?: {
+    field: String | Empty,
   }
 };
 type JsonRule = {

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -282,7 +282,7 @@ export type Types = TypedMap<Type>;
 // Fields
 /////////////////
 
-type FieldType = String | "!struct";
+type FieldType = String | "!struct" | "!group";
 
 interface ListItem {
   value: any,
@@ -355,13 +355,17 @@ interface SimpleField extends ValueField {
   defaultOperator?: String,
   excludeOperators?: Array<String>,
 };
-interface FieldGroup extends BaseField {
+interface FieldStruct extends BaseField {
   type: "!struct",
+  subfields: Fields,
+};
+interface FieldGroup extends BaseField {
+  type: "!group",
   subfields: Fields,
 };
 
 export type Field = SimpleField;
-type FieldOrGroup = FieldGroup | Field;
+type FieldOrGroup = FieldStruct | FieldGroup | Field;
 export type Fields = TypedMap<FieldOrGroup>;
 
 

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -204,7 +204,7 @@ const setField = (state, path, newField, config) => {
     const isRuleGroup = newFieldConfig.type == '!group';
 
     if (isRuleGroup) {
-        state = state.setIn(expandTreePath(path, 'type'), 'group');
+        state = state.setIn(expandTreePath(path, 'type'), 'rule_group');
         let groupProperties = defaultGroupProperties(config).merge({
             field: newField,
         });

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -120,7 +120,7 @@ function _extendFieldConfig(fieldConfig, config, isFuncArg = false) {
     let operators = null, defaultOperator = null;
     const typeConfig = config.types[fieldConfig.type];
     const excludeOperators = fieldConfig.excludeOperators || [];
-    if (fieldConfig.type != '!struct') {
+    if (fieldConfig.type != '!struct' && fieldConfig.type != '!group') {
         if (!isFuncArg) {
             if (!config._fieldsCntByType[fieldConfig.type])
                 config._fieldsCntByType[fieldConfig.type] = 0;
@@ -257,7 +257,7 @@ export const getFirstField = (config) => {
     key = Object.keys(config.fields)[0];
     firstField = config.fields[key];
     keysPath.push(key);
-    while (firstField.type == '!struct') {
+    while (firstField.type == '!struct' || firstField.type == '!group') {
         const subfields = firstField.subfields;
         if (!subfields || !Object.keys(subfields).length) {
             firstField = key = null;

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -183,6 +183,8 @@ export const getFieldRawConfig = (field, config, fieldsKey = 'fields', subfields
     const fieldSeparator = config.settings.fieldSeparator;
     const parts = Array.isArray(field) ? field : field.split(fieldSeparator);
     let fields = config[fieldsKey];
+    if (!fields)
+        return null;
     let fieldConfig = null;
     for (let i = 0 ; i < parts.length ; i++) {
         const part = parts[i];
@@ -250,25 +252,23 @@ export const getFieldConfig = (field, config) => {
     return ret;
 };
 
-export const getFirstField = (config) => {
+export const getFirstField = (config, parentRuleGroupPath = null) => {
   const fieldSeparator = config.settings.fieldSeparator;
-  let firstField = null, key = null, keysPath = [];
-  if (Object.keys(config.fields).length > 0) {
-    key = Object.keys(config.fields)[0];
-    firstField = config.fields[key];
-    keysPath.push(key);
-    while (firstField.type == '!struct' || firstField.type == '!group') {
-        const subfields = firstField.subfields;
-        if (!subfields || !Object.keys(subfields).length) {
-            firstField = key = null;
-            break;
-        }
-        key = Object.keys(subfields)[0];
-        keysPath.push(key);
-        firstField = subfields[key];
+  const parentPathArr = typeof parentRuleGroupPath == 'string' ? parentRuleGroupPath.split(fieldSeparator) : parentRuleGroupPath;
+  const parentField = parentRuleGroupPath ? getFieldRawConfig(parentRuleGroupPath, config) : config;
+
+  let firstField = parentField, key = null, keysPath = [];
+  do {
+    const subfields = firstField === config ? config.fields : firstField.subfields;
+    if (!subfields || !Object.keys(subfields).length) {
+      firstField = key = null;
+      break;
     }
-  }
-  return keysPath.join(fieldSeparator);
+    key = Object.keys(subfields)[0];
+    keysPath.push(key);
+    firstField = subfields[key];
+  } while (firstField.type == '!struct' || firstField.type == '!group');
+  return (parentPathArr || []).concat(keysPath).join(fieldSeparator);
 };
 
 export const getOperatorsForField = (config, field) => {

--- a/modules/utils/defaultUtils.js
+++ b/modules/utils/defaultUtils.js
@@ -4,9 +4,10 @@ import {getFieldConfig, getFirstField, getFirstOperator, getOperatorConfig} from
 import {getNewValueForFieldOp} from '../utils/validation';
 
 
-export const defaultField = (config, canGetFirst = true) => {
+export const defaultField = (config, canGetFirst = true, parentRuleGroupPath = null) => {
   return typeof config.settings.defaultField === 'function' ?
-    config.settings.defaultField() : (config.settings.defaultField || (canGetFirst ? getFirstField(config) : null));
+    config.settings.defaultField(parentRuleGroupPath) : 
+    (config.settings.defaultField || (canGetFirst ? getFirstField(config, parentRuleGroupPath) : null));
 };
 
 export const defaultOperator = (config, field, canGetFirst = true) => {
@@ -33,10 +34,10 @@ export const defaultOperatorOptions = (config, operator, field) => {
   ) : null;
 };
 
-export const defaultRuleProperties = (config) => {
+export const defaultRuleProperties = (config, parentRuleGroupPath = null) => {
   let field = null, operator = null;
-  if (config.settings.setDefaultFieldAndOp) {
-    field = defaultField(config);
+  if (config.settings.setDefaultFieldAndOp || !!parentRuleGroupPath) {
+    field = defaultField(config, true, parentRuleGroupPath);
     operator = defaultOperator(config, field);
   }
   let current = new Immutable.Map({

--- a/modules/utils/defaultUtils.js
+++ b/modules/utils/defaultUtils.js
@@ -36,7 +36,7 @@ export const defaultOperatorOptions = (config, operator, field) => {
 
 export const defaultRuleProperties = (config, parentRuleGroupPath = null) => {
   let field = null, operator = null;
-  if (config.settings.setDefaultFieldAndOp || !!parentRuleGroupPath) {
+  if (config.settings.setDefaultFieldAndOp) {
     field = defaultField(config, true, parentRuleGroupPath);
     operator = defaultOperator(config, field);
   }

--- a/modules/utils/stuff.js
+++ b/modules/utils/stuff.js
@@ -170,7 +170,7 @@ function shallowEqualObjects(objA, objB, deep = false) {
 
   for (var i = 0; i < len; i++) {
     var key = aKeys[i];
-    var isEqual = deep ? shallowEqual(objA[key], objB[key]) : objA[key] === objB[key];
+    var isEqual = deep ? shallowEqual(objA[key], objB[key], deep) : objA[key] === objB[key];
     if (!isEqual) {
       return false;
     }

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -169,6 +169,7 @@ export const getFlatTree = (tree) => {
 
 
 /**
+ * Returns count of reorderable(!) nodes
  * @param {Immutable.Map} tree
  * @return {Integer}
  */
@@ -183,12 +184,16 @@ export const getTotalNodesCountInTree = (tree) => {
         cnt++;
         if (children) {
             children.map((child, childId) => {
-                _processNode(child, path.concat(id), lev + 1);
+                const isRuleGroup = child.get('type') == 'group' && child.getIn(['properties', 'field']) != null;
+                //tip: rules in rule-group can be reordered only inside
+                if (!isRuleGroup) {
+                    _processNode(child, path.concat(id), lev + 1);
+                }
             });
         }
     };
 
     _processNode(tree, [], 0);
 
-    return cnt;
+    return cnt - 1; // -1 for root
 };

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -109,7 +109,7 @@ export const getFlatTree = (tree) => {
     let items = {};
     let realHeight = 0;
 
-    function _flatizeTree (item, path, insideCollapsed, lev, info) {
+    function _flatizeTree (item, path, insideCollapsed, lev, info, parentType) {
         const type = item.get('type');
         const collapsed = item.get('collapsed');
         const id = item.get('id');
@@ -125,7 +125,7 @@ export const getFlatTree = (tree) => {
         if (children) {
             let subinfo = {};
             children.map((child, _childId) => {
-                _flatizeTree(child, path.concat(id), insideCollapsed || collapsed, lev + 1, subinfo);
+                _flatizeTree(child, path.concat(id), insideCollapsed || collapsed, lev + 1, subinfo, type);
             });
             if (!collapsed) {
                 info.height = (info.height || 0) + (subinfo.height || 0);
@@ -134,10 +134,11 @@ export const getFlatTree = (tree) => {
         const itemsAfter = flat.length;
         const _bottom = realHeight;
         const height = info.height;
-
+        
         items[id] = {
             type: type,
             parent: path.length ? path[path.length-1] : null,
+            parentType: parentType,
             path: path.concat(id),
             lev: lev,
             leaf: !children,
@@ -154,7 +155,7 @@ export const getFlatTree = (tree) => {
         };
     }
 
-    _flatizeTree(tree, [], false, 0, {});
+    _flatizeTree(tree, [], false, 0, {}, null);
 
     for (let i = 0 ; i < flat.length ; i++) {
         const prevId = i > 0 ? flat[i-1] : null;

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -182,19 +182,17 @@ export const getTotalNodesCountInTree = (tree) => {
     function _processNode (item, path, lev) {
         const id = item.get('id');
         const children = item.get('children1');
+        const isRuleGroup = item.get('type') == 'rule_group';
         cnt++;
-        if (children) {
-            children.map((child, childId) => {
-                const isRuleGroup = child.get('type') == 'group' && child.getIn(['properties', 'field']) != null;
-                //tip: rules in rule-group can be reordered only inside
-                if (!isRuleGroup) {
-                    _processNode(child, path.concat(id), lev + 1);
-                }
+        //tip: rules in rule-group can be reordered only inside
+        if (children && !isRuleGroup) {
+            children.map((child, _childId) => {
+                _processNode(child, path.concat(id), lev + 1);
             });
         }
     };
 
     _processNode(tree, [], 0);
-
+    
     return cnt - 1; // -1 for root
 };

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -34,7 +34,7 @@ function validateItem (item, path, itemId, meta, c) {
 	const type = item.get('type');
 	const children = item.get('children1');
 
-	if (type === 'group' && children && children.size) {
+	if ((type === 'group' || type === 'rule_group') && children && children.size) {
 		return validateGroup(item, path, itemId, meta, c);
 	} else if (type === 'rule') {
 		return validateRule(item, path, itemId, meta, c);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "reactjs",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "react-awesome-query-builder": "^1.2.0",
+    "react-awesome-query-builder": "^1.3.0",
     "react-scripts": "3.0.1"
   },
   "browserslist": {


### PR DESCRIPTION
We will define a new type named "!group" (just like "!struct") that will have sub subfields,
ones a field of type "!group" will be selected it will be shown like this:
![raqb_elemmatch](https://user-images.githubusercontent.com/3238637/74138420-41703000-4bfa-11ea-8a95-dbe727da1216.png)
and its MongoDB string will be {"product_name": {$elemMatch {"product_type":"a","category":"b"}}
once pressing on "add" a new subfild from the productName !group will be added below of Category