### PR TITLE
Fix wrong funcs prop type in the QueryProps interface

### DIFF
--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -97,7 +97,7 @@ export interface QueryProps {
   types: Types;
   settings: Settings;
   fields: Fields;
-  funcs?: Fincs;
+  funcs?: Funcs;
   value: ImmutableTree;
   onChange(immutableTree: ImmutableTree, config: Config): void;
   renderBuilder(props: BuilderProps): ReactElement;


### PR DESCRIPTION
This PR fixed a typo in the type of the optional `funcs` prop in the QueryProps interface of the Typescript declaration file inside the folder `modules`.

This prevents builds with the `--skipLibCheck` set to false from failing.