### PR TITLE
feat: add operators starts_with and ends_with

### DIFF
--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -197,12 +197,11 @@ const operators = {
     sqlOp: 'LIKE',
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
       if (valueSrc == 'value') {
-          return `${field} LIKE ${values}%`;
+          return `${field} LIKE ${values}`;
       } else return undefined; // not supported
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(`/^${v}/`) : undefined), false),
-    //jsonLogic: (field, op, val) => ({ "starts_with": [val, field] }),
-    jsonLogic: "starts_with",
+    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? "^" + escapeRegExp(v) : undefined), false),
+    jsonLogic: undefined, // not supported
     valueSources: ['value'],
   },
   ends_with: {
@@ -211,12 +210,11 @@ const operators = {
     sqlOp: 'LIKE',
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
       if (valueSrc == 'value') {
-          return `${field} LIKE %${values}`;
+          return `${field} LIKE ${values}`;
       } else return undefined; // not supported
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(`/${v}$/`) : undefined), false),
-    //jsonLogic: (field, op, val) => ({ "ends_with": [val, field] }),
-    jsonLogic: "ends_with",
+    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(v) + "$" : undefined), false),
+    jsonLogic: undefined, // not supported
     valueSources: ['value'],
   },
   between: {
@@ -482,7 +480,11 @@ const widgets = {
           return isForDisplay ? '"' + val + '"' : JSON.stringify(val);
       },
       sqlFormatValue: (val, fieldDef, wgtDef, op, opDef) => {
-          return (op == 'like' || op == 'not_like') ? SqlString.escapeLike(val) : SqlString.escape(val);
+          if (opDef.sqlOp == "LIKE" || opDef.sqlOp == "NOT LIKE") {
+              return SqlString.escapeLike(val, op != 'starts_with', op != 'ends_with');
+          } else {
+              return SqlString.escape(val);
+          }
       },
   },
   number: {

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -191,6 +191,34 @@ const operators = {
       mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(v) : undefined), true),
       valueSources: ['value'],
   },
+  starts_with: {
+    label: 'Starts with',
+    labelForFormat: 'Starts with',
+    sqlOp: 'LIKE',
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+      if (valueSrc == 'value') {
+          return `${field} LIKE ${values}%`;
+      } else return undefined; // not supported
+    },
+    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(`/^${v}/`) : undefined), false),
+    //jsonLogic: (field, op, val) => ({ "starts_with": [val, field] }),
+    jsonLogic: "starts_with",
+    valueSources: ['value'],
+  },
+  ends_with: {
+    label: 'Ends with',
+    labelForFormat: 'Ends with',
+    sqlOp: 'LIKE',
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+      if (valueSrc == 'value') {
+          return `${field} LIKE %${values}`;
+      } else return undefined; // not supported
+    },
+    mongoFormatOp: mongoFormatOp1.bind(null, '$regex', v => (typeof v == 'string' ? escapeRegExp(`/${v}$/`) : undefined), false),
+    //jsonLogic: (field, op, val) => ({ "ends_with": [val, field] }),
+    jsonLogic: "ends_with",
+    valueSources: ['value'],
+  },
   between: {
       label: 'Between',
       labelForFormat: 'BETWEEN',
@@ -648,6 +676,8 @@ const types = {
                   'is_not_empty',
                   'like',
                   'not_like',
+                  'starts_with',
+                  'ends_with',
                   'proximity'
               ],
               widgetProps: {},

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -627,6 +627,8 @@ export interface BasicConfig extends Config {
     greater_or_equal: BinaryOperator,
     like: BinaryOperator,
     not_like: BinaryOperator,
+    starts_with: BinaryOperator,
+    ends_with: BinaryOperator,
     between: Operator2,
     not_between: Operator2,
     range_between: Operator2,

--- a/modules/utils/sql.js
+++ b/modules/utils/sql.js
@@ -7,7 +7,7 @@ SqlString.trim = (val) => {
         return val;
 };
 
-SqlString.escapeLike = (val) => {
+SqlString.escapeLike = (val, any_start = true, any_end = true) => {
     // normal escape
     let res = SqlString.escape(val);
     // unwrap ''
@@ -15,7 +15,7 @@ SqlString.escapeLike = (val) => {
     // escape % and _
     res = res.replace(/[%_]/g, '\\$&');
     // wrap with % for LIKE
-    res = "%" + res + "%";
+    res = (any_start ? "%" : "") + res + (any_end ? "%" : "");
     // wrap ''
     res = "'" + res + "'";
     return res;


### PR DESCRIPTION
I added the operators `starts_with` and `ends_with` at the library. 

To apply rules using `jsonLogic` with the new operators the dev must adjust the `jsonLogic` to recognize the new operators.

to adjust it just follow this tutorial: [http://jsonlogic.com/add_operation.html](http://jsonlogic.com/add_operation.html)