### PR TITLE
Add missing `starts_with` and `ends_with` operators

### DIFF
--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -76,6 +76,8 @@ const {
         greater_or_equal,
         like,
         not_like,
+        starts_with,
+        ends_with,
         between,
         not_between,
         is_empty,


### PR DESCRIPTION
The CONFIG documentation misses out `starts_with` and `ends_with`: https://github.com/ukrbublik/react-awesome-query-builder/blob/514070485ee86fe520d623fbb2be429c0b8f4616/modules/config/basic.js#L194-L219