### PR TITLE
Compile scss to css for bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ import React, {Component} from 'react';
 import {Query, Builder, BasicConfig, Utils as QbUtils} from 'react-awesome-query-builder';
 import AntdConfig from 'react-awesome-query-builder/lib/config/antd';
 import 'react-awesome-query-builder/css/antd.less'; // or import "antd/dist/antd.css";
-import 'react-awesome-query-builder/css/styles.scss';
-import 'react-awesome-query-builder/css/compact_styles.scss'; //optional, for more compact styles
+import 'react-awesome-query-builder/css/styles.css';
+import 'react-awesome-query-builder/css/compact_styles.css'; //optional, for more compact styles
 const InitialConfig = AntdConfig; // or BasicConfig
 
 // You need to provide your own config. See below 'Config format'

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ import React, {Component} from 'react';
 import {Query, Builder, BasicConfig, Utils as QbUtils} from 'react-awesome-query-builder';
 import AntdConfig from 'react-awesome-query-builder/lib/config/antd';
 import 'react-awesome-query-builder/css/antd.less'; // or import "antd/dist/antd.css";
-import 'react-awesome-query-builder/css/styles.css';
-import 'react-awesome-query-builder/css/compact_styles.css'; //optional, for more compact styles
+import 'react-awesome-query-builder/lib/css/styles.css';
+import 'react-awesome-query-builder/lib/css/compact_styles.css'; //optional, for more compact styles
 const InitialConfig = AntdConfig; // or BasicConfig
 
 // You need to provide your own config. See below 'Config format'

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -1,5 +1,6 @@
 rm -rf lib
 babel -d lib ./modules
+node-sass css/ -o lib/css/ --output-style compressed
 cp modules/index.d.ts lib/index.d.ts
 cp modules/config/antd/index.d.ts lib/config/antd/index.d.ts
 cp modules/components/widgets/antd/index.d.ts lib/components/widgets/antd/index.d.ts


### PR DESCRIPTION
Compile the sass files to plain css so users don't need to install sass as a dependency #179 