### PR TITLE
Fix bug: the [VanillaNumber] component can't correctly deal with float step value

### DIFF
--- a/modules/components/widgets/vanilla/value/VanillaNumber.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaNumber.jsx
@@ -7,7 +7,7 @@ export default (props) => {
     if (val === "" || val === null)
       val = undefined;
     else
-      val = parseInt(val);
+    val =  Number.isInteger(step) ? parseInt(val) : parseFloat(val);
     setValue(val);
   };
   return (

--- a/modules/components/widgets/vanilla/value/VanillaNumber.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaNumber.jsx
@@ -7,7 +7,7 @@ export default (props) => {
     if (val === "" || val === null)
       val = undefined;
     else
-    val =  Number.isInteger(step) ? parseInt(val) : parseFloat(val);
+      val =  Number.isInteger(step) ? parseInt(val) : parseFloat(val);
     setValue(val);
   };
   return (


### PR DESCRIPTION
For example, user set step value to 0.1, which means user expects a float value in the input box. 

However, existing parseInt will always return integer value.