### PR TITLE
Modify NumberFieldSettings.step to accept the "any" string literal.

### DIFF
--- a/modules/components/widgets/vanilla/value/VanillaNumber.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaNumber.jsx
@@ -7,7 +7,7 @@ export default (props) => {
     if (val === "" || val === null)
       val = undefined;
     else
-      val = parseInt(val);
+      val = Number.isInteger(step) ? parseInt(val, 10) : parseFloat(val);
     setValue(val);
   };
   return (

--- a/modules/components/widgets/vanilla/value/VanillaNumber.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaNumber.jsx
@@ -7,7 +7,7 @@ export default (props) => {
     if (val === "" || val === null)
       val = undefined;
     else
-      val = Number.isInteger(step) ? parseInt(val, 10) : parseFloat(val);
+      val = parseInt(val);
     setValue(val);
   };
   return (

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -389,7 +389,7 @@ export interface BasicFieldSettings {
 export interface NumberFieldSettings extends BasicFieldSettings {
   min?: number,
   max?: number,
-  step?: number,
+  step?: number | "any",
   marks?: {[mark: number]: ReactElement | string}
 };
 export interface DateTimeFieldSettings extends BasicFieldSettings {


### PR DESCRIPTION
According to [this MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step), step may accept either a number or the "any" string literal, allowing any number of decimals in the latter case.