### PR TITLE
custom store context

### DIFF
--- a/modules/components/Query.jsx
+++ b/modules/components/Query.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PureComponent } from "react";
 import PropTypes from "prop-types";
 import createTreeStore from "../stores/tree";
+import context from "../stores/context";
 import {createStore} from "redux";
 import {Provider, Connector, connect} from "react-redux";
 import * as actions from "../actions";
@@ -90,6 +91,11 @@ const ConnectedQuery = connect(
       __isInternalValueChange: state.__isInternalValueChange,
     };
   },
+  null,
+  null,
+  {
+    context
+  }
 )(Query);
 ConnectedQuery.displayName = "ConnectedQuery";
 
@@ -162,7 +168,7 @@ export default class QueryContainer extends Component {
 
       return (
         <QueryWrapper config={config}>
-          <Provider store={store}>
+          <Provider store={store} context={context}>
             <ConnectedQuery
               store={store}
               config={config}

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import mapValues from "lodash/mapValues";
+import context from "../../stores/context";
 import {pureShouldComponentUpdate} from "../../utils/renderUtils";
 import {connect} from "react-redux";
 import {useOnPropsChanged} from "../../utils/stuff";
@@ -188,6 +189,11 @@ export default (Group) => {
       return {
         dragging: state.dragging,
       };
+    },
+    null,
+    null,
+    {
+      context
     }
   )(GroupContainer);
   ConnectedGroupContainer.displayName = "ConnectedGroupContainer";

--- a/modules/components/containers/RuleContainer.jsx
+++ b/modules/components/containers/RuleContainer.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import context from "../../stores/context";
 import {getFieldConfig} from "../../utils/configUtils";
 import {pureShouldComponentUpdate} from "../../utils/renderUtils";
 import {connect} from "react-redux";
@@ -162,6 +163,11 @@ export default (Rule) => {
       return {
         dragging: state.dragging,
       };
+    },
+    null,
+    null,
+    {
+      context
     }
   )(RuleContainer);
   ConnectedRuleContainer.displayName = "ConnectedRuleContainer";

--- a/modules/components/containers/SortableContainer.jsx
+++ b/modules/components/containers/SortableContainer.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import {connect} from "react-redux";
+import context from "../../stores/context";
 import {getFlatTree} from "../../utils/treeUtils";
 import * as constants from "../../constants";
 import clone from "clone";
@@ -553,6 +554,10 @@ export default (Builder, CanMoveFn = null) => {
       setDragStart: actions.drag.setDragStart,
       setDragProgress: actions.drag.setDragProgress,
       setDragEnd: actions.drag.setDragEnd,
+    },
+    null,
+    {
+      context
     }
   )(SortableContainer);
   ConnectedSortableContainer.displayName = "ConnectedSortableContainer";

--- a/modules/stores/context.js
+++ b/modules/stores/context.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export default React.createContext();


### PR DESCRIPTION
Added custom context to isolate Query Builder store, according https://react-redux.js.org/using-react-redux/accessing-store#multiple-stores

I faced with the issue to pass custom widget in which the redux connect is used. Instead of the original store it used the store of Query Builder. Isolation should help here.