### PR TITLE
Provide used values under data field in JsonLogic response

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Wrapping in `div.query-builder-container` is necessary if you put query builder 
   Convert query value to SQL where string.
   #### jsonLogicFormat (immutableValue, config) -> {logic, data, errors}
   Convert query value to [JsonLogic](http://jsonlogic.com) format. 
-  If there are no `errors`, `logic` will be rule object and `data` will contain all used fields with null values ("template" data).
+  If there are no `errors`, `logic` will be rule object and `data` will contain all used fields with either the threshold value used in the rules, or `null` as a fallback ("template" data).
 - Import:
   #### loadFromJsonLogic (jsonLogicObject, config) -> Immutable
   Convert query value from [JsonLogic](http://jsonlogic.com) format to internal Immutable format. 

--- a/modules/export/jsonLogic.js
+++ b/modules/export/jsonLogic.js
@@ -237,7 +237,7 @@ const jsonLogicFormatItem = (item, config, meta, isRoot, parentField = null) => 
       const valueSrc = properties.get("valueSrc") ? properties.get("valueSrc").get(ind) : null;
       const valueType = properties.get("valueType") ? properties.get("valueType").get(ind) : null;
       currentValue = completeValue(currentValue, valueSrc, config);
-      if (!meta.usedValues[field] && typeof currentValue !== 'object')
+      if (!meta.usedValues[field] && typeof currentValue !== "object")
         meta.usedValues[field] = currentValue;
       const widget = getWidgetForFieldOp(config, field, operator, valueSrc);
       const fieldWidgetDefinition = omit(getFieldWidgetConfig(config, field, operator, widget, valueSrc), ["factory"]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-awesome-query-builder",
-  "version": "3.0.0",
+  "name": "@sebranly/react-awesome-query-builder",
+  "version": "4.0.6",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",
@@ -28,7 +28,7 @@
   "main": "lib",
   "types": "modules/index.d.ts",
   "scripts": {
-    "prepublish": "npm run build-npm",
+    "prepare": "npm run build-npm",
     "for-npm": "./scripts/for-npm.sh",
     "for-gpr": "./scripts/for-gpr.sh",
     "build-npm": "./scripts/build-npm.sh",
@@ -42,6 +42,7 @@
     "lint-fix": "./node_modules/.bin/eslint --ext .jsx --ext .js --ext .tsx --fix ./modules/ ./sandbox/ ./sandbox_simple/ ./examples/ ./tests/",
     "lint": "./node_modules/.bin/eslint --ext .jsx --ext .js --ext .tsx ./modules/ ./sandbox/ ./sandbox_simple/ ./examples/ ./tests/"
   },
+  "private": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/ukrbublik/react-awesome-query-builder.git"
@@ -52,7 +53,9 @@
     "url": "https://github.com/ukrbublik/react-awesome-query-builder/issues"
   },
   "homepage": "https://github.com/ukrbublik/react-awesome-query-builder",
-  "funding": "https://opencollective.com/react-awesome-query-builder",
+  "funding": {
+    "url": "https://opencollective.com/react-awesome-query-builder"
+  },
   "engines": {
     "node": ">=10.14",
     "npm": ">=6"


### PR DESCRIPTION
Previously, `data` field from `jsonLogicFormat` would return `null` as template values for the fields present in the rules.
Now, with this PR `data` field from `jsonLogicFormat` will return the threshold values (the ones from the rules) ; otherwise `null` as the fallback.

<img width="685" alt="Screenshot 2021-04-26 at 16 24 52" src="https://user-images.githubusercontent.com/25478895/116099838-a8b5bb00-a6ac-11eb-8ef8-f6a2e2e63499.png">

|Before this PR|With this PR|
|-|-|
|<img width="185" alt="Screenshot 2021-04-26 at 16 25 00" src="https://user-images.githubusercontent.com/25478895/116099891-b4a17d00-a6ac-11eb-8e9f-0cfb17253b9d.png">|<img width="196" alt="Screenshot 2021-04-26 at 16 26 44" src="https://user-images.githubusercontent.com/25478895/116099972-c71bb680-a6ac-11eb-8447-2e1a4474e791.png">|

Notice how fields under `user` still have the `null` template (fallback) because this case is more complex.

One use-case could be creating toggles based on the rules e.g.
- a user uses `react-awesome-query-builder` to visually create rules being saved as JSONLogic
- the user now wants to create toggles based on those JSONLogic rules

For instance in the example above, the user would like to create a toggle under this form:
- `results.product`
  - `abc` (button 1)
  - Not `abc` (button 2)