### PR TITLE
Provide used values under data field in JsonLogic response

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Wrapping in `div.query-builder-container` is necessary if you put query builder 
   Convert query value to SQL where string.
   #### jsonLogicFormat (immutableValue, config) -> {logic, data, errors}
   Convert query value to [JsonLogic](http://jsonlogic.com) format. 
-  If there are no `errors`, `logic` will be rule object and `data` will contain all used fields with null values ("template" data).
+  If there are no `errors`, `logic` will be rule object and `data` will contain all used fields with either the threshold value used in the rules, or `null` as a fallback ("template" data).
 - Import:
   #### loadFromJsonLogic (jsonLogicObject, config) -> Immutable
   Convert query value from [JsonLogic](http://jsonlogic.com) format to internal Immutable format. 

--- a/modules/export/jsonLogic.js
+++ b/modules/export/jsonLogic.js
@@ -237,7 +237,7 @@ const jsonLogicFormatItem = (item, config, meta, isRoot, parentField = null) => 
       const valueSrc = properties.get("valueSrc") ? properties.get("valueSrc").get(ind) : null;
       const valueType = properties.get("valueType") ? properties.get("valueType").get(ind) : null;
       currentValue = completeValue(currentValue, valueSrc, config);
-      if (!meta.usedValues[field] && typeof currentValue !== 'object')
+      if (!meta.usedValues[field] && typeof currentValue !== "object")
         meta.usedValues[field] = currentValue;
       const widget = getWidgetForFieldOp(config, field, operator, valueSrc);
       const fieldWidgetDefinition = omit(getFieldWidgetConfig(config, field, operator, widget, valueSrc), ["factory"]);


### PR DESCRIPTION
Previously, `data` field from `jsonLogicFormat` would return `null` as template values for the fields present in the rules.
Now, with this PR `data` field from `jsonLogicFormat` will return the threshold values (the ones from the rules) ; otherwise `null` as the fallback.

<img width="685" alt="Screenshot 2021-04-26 at 16 24 52" src="https://user-images.githubusercontent.com/25478895/116099838-a8b5bb00-a6ac-11eb-8ef8-f6a2e2e63499.png">

|Before this PR|With this PR|
|-|-|
|<img width="185" alt="Screenshot 2021-04-26 at 16 25 00" src="https://user-images.githubusercontent.com/25478895/116099891-b4a17d00-a6ac-11eb-8e9f-0cfb17253b9d.png">|<img width="196" alt="Screenshot 2021-04-26 at 16 26 44" src="https://user-images.githubusercontent.com/25478895/116099972-c71bb680-a6ac-11eb-8447-2e1a4474e791.png">|

Notice how fields under `user` still have the `null` template (fallback) because this case is more complex.

One use-case could be creating toggles based on the rules e.g.
- a user uses `react-awesome-query-builder` to visually create rules being saved as JSONLogic
- the user now wants to create toggles based on those JSONLogic rules

For instance in the example above, the user would like to create a toggle under this form:
- `results.product`
  - `abc` (button 1)
  - Not `abc` (button 2)