### PR TITLE
Fix drag-n-drop with FluentUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+- 4.0.4
+  - Fixed issue #349 with drag-n-drop and office-ui-fabric-react
 - 4.0.3
   - Fixed issue #386 with import select field from JsonLogic (reason: bug with func/field widget in getWidgetForFieldOp)
   - Fixed issue #387 with subgroups in Material UI 

--- a/modules/components/containers/SortableContainer.jsx
+++ b/modules/components/containers/SortableContainer.jsx
@@ -139,6 +139,10 @@ export default (Builder, CanMoveFn = null) => {
       }
     }
 
+    _getEventTarget = (e, dragStart) => {
+      return e && e.__mocked_window || document.body || window;
+    }
+
     onDragStart = (id, dom, e) => {
       let treeEl = dom.closest(".query-builder");
       document.body.classList.add("qb-dragging");
@@ -183,7 +187,8 @@ export default (Builder, CanMoveFn = null) => {
         clientY: e.clientY,
       };
 
-      const target = e.__mocked_window || window;
+      const target = this._getEventTarget(e, dragStart);
+      this.eventTarget = target;
       target.addEventListener("mousemove", this.onDrag);
       target.addEventListener("mouseup", this.onDragEnd);
 
@@ -263,10 +268,11 @@ export default (Builder, CanMoveFn = null) => {
       document.body.classList.remove("qb-dragging");
       this._cacheEls = {};
 
-      window.removeEventListener("mousemove", this.onDrag);
-      window.removeEventListener("mouseup", this.onDragEnd);
+      const target = this.eventTarget || this._getEventTarget();
+      target.removeEventListener("mousemove", this.onDrag);
+      target.removeEventListener("mouseup", this.onDragEnd);
     }
-
+    
 
     handleDrag (dragInfo, e, canMoveFn) {
       const canMoveBeforeAfterGroup = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",


### PR DESCRIPTION
Resolves https://github.com/ukrbublik/react-awesome-query-builder/issues/349

When RAQB in rendered inside `<Panel>` of [office-ui-fabric-react](https://www.npmjs.com/package/office-ui-fabric-react) (Fluent UI), `mousemove` events listening from `window` is not working for some reason.
Simple solution - attach event listener to `document.body` instead