### PR TITLE
RELATIVE_DATETIME, NOW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+- 4.3.0
+  - Improved function support
+  - Functions used in examples now moved to `BasicFuncs` (exported with lib)
+  - Added funcs `RELATIVE_DATETIME`, `NOW`, `UPPER`
+  - Added option `showPrefix` for func args (false by default)
+  - Added missing `mongoFormatValue` for all types in basic config (now dates are exported as `Date` objects)
 - 4.2.0
   - Added `textarea` widget
 - 4.1.1

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -521,7 +521,6 @@ export default (skin: string) => {
           type: "date",
           defaultValue: "NOW",
           valueSources: ["const"],
-          showPrefix: false,
         },
         op: {
           type: "select",

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -374,7 +374,7 @@ export default (skin: string) => {
     date: {
       label: "Date",
       type: "date",
-      //valueSources: ["value"],
+      valueSources: ["value"],
       fieldSettings: {
         dateFormat: "DD-MM-YYYY",
         validateValue: (val, fieldSettings: DateTimeFieldSettings) => {
@@ -393,7 +393,7 @@ export default (skin: string) => {
     datetime: {
       label: "DateTime",
       type: "datetime",
-      valueSources: ["value"]
+      valueSources: ["value", "func"]
     },
     datetime2: {
       label: "DateTime2",

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -374,7 +374,7 @@ export default (skin: string) => {
     date: {
       label: "Date",
       type: "date",
-      valueSources: ["value"],
+      //valueSources: ["value"],
       fieldSettings: {
         dateFormat: "DD-MM-YYYY",
         validateValue: (val, fieldSettings: DateTimeFieldSettings) => {
@@ -511,6 +511,61 @@ export default (skin: string) => {
   //////////////////////////////////////////////////////////////////////
 
   const funcs: Funcs = {
+    RELATIVE_DATE: {
+      label: "Relative",
+      returnType: "date",
+      renderBrackets: ["", ""],
+      renderSeps: ["", "", ""],
+      args: {
+        now: {
+          type: "date",
+          defaultValue: "NOW",
+          valueSources: ["const"],
+          showPrefix: false,
+        },
+        op: {
+          type: "select",
+          defaultValue: "plus",
+          valueSources: ["value"],
+          mainWidgetProps: {
+            customProps: {
+              showSearch: false
+            }
+          },
+          fieldSettings: {
+            listValues: {
+              plus: "+",
+              minus: "-",
+            },
+          }
+        },
+        val: {
+          label: "Value",
+          type: "number",
+          defaultValue: 1,
+          valueSources: ["value"],
+        },
+        dim: {
+          label: "Dimention",
+          type: "select",
+          defaultValue: "day",
+          valueSources: ["value"],
+          mainWidgetProps: {
+            customProps: {
+              showSearch: false
+            }
+          },
+          fieldSettings: {
+            listValues: {
+              day: "day",
+              week: "week",
+              month: "month",
+              year: "year",
+            },
+          }
+        },
+      }
+    },
     LOWER: {
       label: "Lowercase",
       mongoFunc: "$toLower",

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -510,12 +510,33 @@ export default (skin: string) => {
 
   //////////////////////////////////////////////////////////////////////
 
+  //todo: add jsonlogic extension for now, date_add, toLowerCase
+
   const funcs: Funcs = {
     RELATIVE_DATE: {
       label: "Relative",
       returnType: "date",
       renderBrackets: ["", ""],
       renderSeps: ["", "", ""],
+      jsonLogic: ({_now, op, val, dim}) => ({
+        "date_add": [
+          {"now": []},
+          val * (op == "minus" ? -1 : +1),
+          dim
+        ]
+      }),
+      /* eslint-disable */
+      jsonLogicImport: (v: any) => {
+        const now = "NOW";
+        const val = Math.abs(v["date_add"][1]);
+        const op = v["date_add"][1] >= 0 ? "plus" : "minus";
+        const dim = v["date_add"][2];
+        return [now, op, val, dim];
+      },
+      // MySQL
+      sqlFormatFunc: ({_now, op, val, dim}) => `DATE_ADD(${"NOW()"}, INTERVAL ${parseInt(val) * (op == "minus" ? -1 : +1)} ${dim.replace(/^'|'$/g, '')})`,
+      /* eslint-enable */
+      mongoFormatFunc: null, // not supported
       args: {
         now: {
           type: "date",
@@ -541,6 +562,9 @@ export default (skin: string) => {
         val: {
           label: "Value",
           type: "number",
+          fieldSettings: {
+            min: 0,
+          },
           defaultValue: 1,
           valueSources: ["value"],
         },

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -1,7 +1,7 @@
 import React, {Component} from "react";
 import merge from "lodash/merge";
 import {
-  BasicConfig,
+  BasicConfig, BasicFuncs,
   // types:
   Operators, Widgets, Fields, Config, Types, Conjunctions, Settings, LocaleSettings, OperatorProximity, Funcs, 
   DateTimeFieldSettings,
@@ -510,138 +510,9 @@ export default (skin: string) => {
 
   //////////////////////////////////////////////////////////////////////
 
-  //todo: add jsonlogic extension for now, date_add, toLowerCase
-
   const funcs: Funcs = {
-    RELATIVE_DATE: {
-      label: "Relative",
-      returnType: "date",
-      renderBrackets: ["", ""],
-      renderSeps: ["", "", ""],
-      jsonLogic: ({_now, op, val, dim}) => ({
-        "date_add": [
-          {"now": []},
-          val * (op == "minus" ? -1 : +1),
-          dim
-        ]
-      }),
-      /* eslint-disable */
-      jsonLogicImport: (v: any) => {
-        const now = "NOW";
-        const val = Math.abs(v["date_add"][1]);
-        const op = v["date_add"][1] >= 0 ? "plus" : "minus";
-        const dim = v["date_add"][2];
-        return [now, op, val, dim];
-      },
-      // MySQL
-      sqlFormatFunc: ({_now, op, val, dim}) => `DATE_ADD(${"NOW()"}, INTERVAL ${parseInt(val) * (op == "minus" ? -1 : +1)} ${dim.replace(/^'|'$/g, '')})`,
-      /* eslint-enable */
-      mongoFormatFunc: null, // not supported
-      args: {
-        now: {
-          type: "date",
-          defaultValue: "NOW",
-          valueSources: ["const"],
-        },
-        op: {
-          type: "select",
-          defaultValue: "plus",
-          valueSources: ["value"],
-          mainWidgetProps: {
-            customProps: {
-              showSearch: false
-            }
-          },
-          fieldSettings: {
-            listValues: {
-              plus: "+",
-              minus: "-",
-            },
-          }
-        },
-        val: {
-          label: "Value",
-          type: "number",
-          fieldSettings: {
-            min: 0,
-          },
-          defaultValue: 1,
-          valueSources: ["value"],
-        },
-        dim: {
-          label: "Dimention",
-          type: "select",
-          defaultValue: "day",
-          valueSources: ["value"],
-          mainWidgetProps: {
-            customProps: {
-              showSearch: false
-            }
-          },
-          fieldSettings: {
-            listValues: {
-              day: "day",
-              week: "week",
-              month: "month",
-              year: "year",
-            },
-          }
-        },
-      }
-    },
-    LOWER: {
-      label: "Lowercase",
-      mongoFunc: "$toLower",
-      jsonLogic: "toLowerCase",
-      //jsonLogicIsMethod: true, // Removed in JsonLogic 2.x due to Prototype Pollution
-      returnType: "text",
-      args: {
-        str: {
-          label: "String",
-          type: "text",
-          valueSources: ["value", "field"],
-        },
-      }
-    },
-    LINEAR_REGRESSION: {
-      label: "Linear regression",
-      returnType: "number",
-      formatFunc: ({coef, bias, val}, _) => `(${coef} * ${val} + ${bias})`,
-      sqlFormatFunc: ({coef, bias, val}) => `(${coef} * ${val} + ${bias})`,
-      mongoFormatFunc: ({coef, bias, val}) => ({"$sum": [{"$multiply": [coef, val]}, bias]}),
-      jsonLogic: ({coef, bias, val}) => ({ "+": [ {"*": [coef, val]}, bias ] }),
-      /* eslint-disable */
-      jsonLogicImport: (v: any) => {
-        const coef = v["+"][0]["*"][0];
-        const val = v["+"][0]["*"][1];
-        const bias = v["+"][1];
-        return [coef, val, bias];
-      },
-      /* eslint-enable */
-      renderBrackets: ["", ""],
-      renderSeps: [" * ", " + "],
-      args: {
-        coef: {
-          label: "Coef",
-          type: "number",
-          defaultValue: 1,
-          valueSources: ["value"],
-        },
-        val: {
-          label: "Value",
-          type: "number",
-          valueSources: ["value"],
-        },
-        bias: {
-          label: "Bias",
-          type: "number",
-          defaultValue: 0,
-          valueSources: ["value"],
-        }
-      }
-    },
+    ...BasicFuncs
   };
-
 
 
   const config: Config = {

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -22,6 +22,10 @@ let plugins = [
             NODE_ENV: JSON.stringify(MODE),
         }
     }),
+    new webpack.ProvidePlugin({
+        process: 'process/browser',
+        Buffer: ['buffer', 'Buffer'],
+    }),
 ];
 let aliases = {
     [lib_name]: MODULES

--- a/modules/components/rule/FuncWidget.jsx
+++ b/modules/components/rule/FuncWidget.jsx
@@ -89,21 +89,23 @@ export default class FuncWidget extends PureComponent {
   };
 
   renderArgLabel = (argKey, argDefinition) => {
+    const {valueSources, type, showPrefix, label} = argDefinition;
     const {config} = this.props;
-    const isConst = argDefinition.valueSources && argDefinition.valueSources.length == 1 && argDefinition.valueSources[0] == "const";
-    const forceShow = !config.settings.showLabels && (argDefinition.type == "boolean" || isConst);
+    const isConst = valueSources && valueSources.length == 1 && valueSources[0] == "const";
+    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix !== false;
     if (!forceShow) return null;
     return (
       <Col className="rule--func--arg-label">
-        {argDefinition.label || argKey}
+        {label || argKey}
       </Col>
     );
   };
 
   renderArgLabelSep = (argKey, argDefinition) => {
+    const {valueSources, type, showPrefix} = argDefinition;
     const {config} = this.props;
-    const isConst = argDefinition.valueSources && argDefinition.valueSources.length == 1 && argDefinition.valueSources[0] == "const";
-    const forceShow = !config.settings.showLabels && (argDefinition.type == "boolean" || isConst);
+    const isConst = valueSources && valueSources.length == 1 && valueSources[0] == "const";
+    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix !== false;
     if (!forceShow) return null;
     return (
       <Col className="rule--func--arg-label-sep">

--- a/modules/components/rule/FuncWidget.jsx
+++ b/modules/components/rule/FuncWidget.jsx
@@ -92,7 +92,7 @@ export default class FuncWidget extends PureComponent {
     const {valueSources, type, showPrefix, label} = argDefinition;
     const {config} = this.props;
     const isConst = valueSources && valueSources.length == 1 && valueSources[0] == "const";
-    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix !== false;
+    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix;
     if (!forceShow) return null;
     return (
       <Col className="rule--func--arg-label">
@@ -105,7 +105,7 @@ export default class FuncWidget extends PureComponent {
     const {valueSources, type, showPrefix} = argDefinition;
     const {config} = this.props;
     const isConst = valueSources && valueSources.length == 1 && valueSources[0] == "const";
-    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix !== false;
+    const forceShow = !config.settings.showLabels && (type == "boolean" || isConst) && showPrefix;
     if (!forceShow) return null;
     return (
       <Col className="rule--func--arg-label-sep">

--- a/modules/components/rule/FuncWidget.jsx
+++ b/modules/components/rule/FuncWidget.jsx
@@ -14,11 +14,12 @@ export default class FuncWidget extends PureComponent {
   static propTypes = {
     config: PropTypes.object.isRequired,
     field: PropTypes.string.isRequired,
-    operator: PropTypes.string.isRequired,
+    operator: PropTypes.string,
     customProps: PropTypes.object,
     value: PropTypes.object, //instanceOf(Immutable.Map) //with keys 'func' and `args`
     setValue: PropTypes.func.isRequired,
     readonly: PropTypes.bool,
+    parentFuncs: PropTypes.array,
   };
 
   constructor(props) {
@@ -68,12 +69,12 @@ export default class FuncWidget extends PureComponent {
   };
 
   renderFuncSelect = () => {
-    const {config, field, operator, customProps, value, readonly} = this.props;
+    const {config, field, operator, customProps, value, readonly, parentFuncs} = this.props;
     const funcKey = value ? value.get("func") : null;
     const selectProps = {
       value: funcKey,
       setValue: this.setFunc,
-      config, field, operator, customProps, readonly,
+      config, field, operator, customProps, readonly, parentFuncs,
     };
     const {showLabels, funcLabel} = config.settings;
     const widgetLabel = showLabels
@@ -115,7 +116,7 @@ export default class FuncWidget extends PureComponent {
   };
 
   renderArgVal = (funcKey, argKey, argDefinition) => {
-    const {config, field, operator, value, readonly} = this.props;
+    const {config, field, operator, value, readonly, parentFuncs} = this.props;
     const arg = value ? value.getIn(["args", argKey]) : null;
     const argVal = arg ? arg.get("value") : undefined;
     const defaultValueSource = argDefinition.valueSources.length == 1 ? argDefinition.valueSources[0] : undefined;
@@ -135,6 +136,7 @@ export default class FuncWidget extends PureComponent {
       argKey,
       argDefinition,
       readonly,
+      parentFuncs,
     };
     //tip: value & valueSrc will be converted to Immutable.List at <Widget>
 
@@ -212,6 +214,7 @@ class ArgWidget extends PureComponent {
     setValue: PropTypes.func.isRequired,
     setValueSrc: PropTypes.func.isRequired,
     readonly: PropTypes.bool,
+    parentFuncs: PropTypes.array,
   };
 
   setValue = (_delta, value, _widgetType) => {
@@ -225,12 +228,14 @@ class ArgWidget extends PureComponent {
   }
 
   render() {
+    const {funcKey, parentFuncs} = this.props;
     return (
       <Widget
         {...this.props} 
         setValue={this.setValue} 
         setValueSrc={this.setValueSrc} 
         isFuncArg={true}
+        parentFuncs={[...(parentFuncs || []), funcKey]}
       />
     );
   }

--- a/modules/components/rule/Widget.jsx
+++ b/modules/components/rule/Widget.jsx
@@ -36,6 +36,8 @@ export default class Widget extends PureComponent {
     // for RuleGroupExt
     isForRuleGruop: PropTypes.bool,
     parentField: PropTypes.string,
+    // for func in func
+    parentFuncs: PropTypes.array,
   };
 
   constructor(props) {
@@ -162,7 +164,7 @@ export default class Widget extends PureComponent {
   }
 
   renderWidget = (delta, meta, props) => {
-    const {config, isFuncArg, leftField, operator, value: values, valueError, readonly, parentField} = props;
+    const {config, isFuncArg, leftField, operator, value: values, valueError, readonly, parentField, parentFuncs} = props;
     const {settings} = config;
     const { widgets, iValues, aField } = meta;
     const value = isFuncArg ? iValues : values;
@@ -187,6 +189,7 @@ export default class Widget extends PureComponent {
           config={config}
           field={field}
           parentField={parentField}
+          parentFuncs={parentFuncs}
           operator={operator}
           readonly={readonly}
         />

--- a/modules/components/rule/WidgetFactory.jsx
+++ b/modules/components/rule/WidgetFactory.jsx
@@ -6,7 +6,7 @@ export default ({
   value: immValue, valueError: immValueError,
   isSpecialRange, fieldDefinition,
   widget, widgetDefinition, widgetValueLabel, valueLabels, textSeparators, setValueHandler,
-  config, field, operator, readonly, parentField,
+  config, field, operator, readonly, parentField, parentFuncs,
 }) => {
   const {factory: widgetFactory, ...fieldWidgetProps} = widgetDefinition;
   const isConst = isFuncArg && fieldDefinition.valueSources && fieldDefinition.valueSources.length == 1 && fieldDefinition.valueSources[0] == "const";
@@ -30,6 +30,7 @@ export default ({
     config: config,
     field: field,
     parentField: parentField,
+    parentFuncs: parentFuncs,
     fieldDefinition: fieldDefinition,
     operator: operator,
     delta: delta,

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -481,6 +481,7 @@ const widgets = {
       }
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   textarea: {
     type: "text",
@@ -500,6 +501,7 @@ const widgets = {
       }
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
     fullWidth: true,
   },
   number: {
@@ -520,6 +522,7 @@ const widgets = {
       return SqlString.escape(val);
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   slider: {
     type: "number",
@@ -535,6 +538,7 @@ const widgets = {
       return SqlString.escape(val);
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   select: {
     type: "select",
@@ -551,6 +555,7 @@ const widgets = {
       return SqlString.escape(val);
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   multiselect: {
     type: "multiselect",
@@ -567,6 +572,7 @@ const widgets = {
       return vals.map(v => SqlString.escape(v));
     },
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   date: {
     type: "date",
@@ -595,6 +601,10 @@ const widgets = {
       const dateVal = moment(val, fieldSettings.valueFormat);
       return dateVal.isValid() ? dateVal.toDate() : undefined;
     },
+    mongoFormatValue: (val, fieldDef, wgtDef) => {
+      const dateVal = moment(val, wgtDef.valueFormat);
+      return dateVal.isValid() ? dateVal.toDate() : undefined;
+    }
   },
   time: {
     type: "time",
@@ -629,6 +639,11 @@ const widgets = {
       const dateVal = moment(val, fieldSettings.valueFormat);
       return dateVal.isValid() ? dateVal.get("hour") * 60 * 60 + dateVal.get("minute") * 60 + dateVal.get("second") : undefined;
     },
+    mongoFormatValue: (val, fieldDef, wgtDef) => {
+      // return seconds of day
+      const dateVal = moment(val, wgtDef.valueFormat);
+      return dateVal.get("hour") * 60 * 60 + dateVal.get("minute") * 60 + dateVal.get("second");
+    },
   },
   datetime: {
     type: "datetime",
@@ -659,6 +674,10 @@ const widgets = {
       const dateVal = moment(val, fieldSettings.valueFormat);
       return dateVal.isValid() ? dateVal.toDate() : undefined;
     },
+    mongoFormatValue: (val, fieldDef, wgtDef) => {
+      const dateVal = moment(val, wgtDef.valueFormat);
+      return dateVal.isValid() ? dateVal.toDate() : undefined;
+    }
   },
   boolean: {
     type: "boolean",
@@ -675,6 +694,7 @@ const widgets = {
     },
     defaultValue: false,
     toJS: (val, fieldSettings) => (val),
+    mongoFormatValue: (val, fieldDef, wgtDef) => (val),
   },
   field: {
     valueSrc: "field",

--- a/modules/config/funcs.js
+++ b/modules/config/funcs.js
@@ -1,4 +1,4 @@
-
+import moment from "moment";
 
 const NOW = {
   label: "Now",
@@ -38,7 +38,7 @@ const RELATIVE_DATETIME = {
   },
   // MySQL
   //todo: other SQL dialects?
-  sqlFormatFunc: ({date, op, val, dim}) => `DATE_ADD(${date}, INTERVAL ${parseInt(val) * (op == "minus" ? -1 : +1)} ${dim.replace(/^'|'$/g, '')})`,
+  sqlFormatFunc: ({date, op, val, dim}) => `DATE_ADD(${date}, INTERVAL ${parseInt(val) * (op == "minus" ? -1 : +1)} ${dim.replace(/^'|'$/g, "")})`,
   mongoFormatFunc: null, //todo: support?
   formatFunc: ({date, op, val, dim}) => (!val ? date : `${date} ${op == "minus" ? "-" : "+"} ${val} ${dim}`),
   args: {

--- a/modules/config/funcs.js
+++ b/modules/config/funcs.js
@@ -1,0 +1,136 @@
+
+  //todo: add jsonlogic extension for now, date_add, toLowerCase
+  
+const RELATIVE_DATE = {
+  label: "Relative",
+  returnType: "date",
+  renderBrackets: ["", ""],
+  renderSeps: ["", "", ""],
+  jsonLogic: ({_now, op, val, dim}) => ({
+    "date_add": [
+      {"now": []},
+      val * (op == "minus" ? -1 : +1),
+      dim
+    ]
+  }),
+  jsonLogicImport: (v) => {
+    const now = "NOW";
+    const val = Math.abs(v["date_add"][1]);
+    const op = v["date_add"][1] >= 0 ? "plus" : "minus";
+    const dim = v["date_add"][2];
+    return [now, op, val, dim];
+  },
+  // MySQL
+  sqlFormatFunc: ({_now, op, val, dim}) => `DATE_ADD(${"NOW()"}, INTERVAL ${parseInt(val) * (op == "minus" ? -1 : +1)} ${dim.replace(/^'|'$/g, '')})`,
+  mongoFormatFunc: null, // not supported
+  args: {
+    now: {
+      type: "date",
+      defaultValue: "NOW",
+      valueSources: ["const"],
+    },
+    op: {
+      type: "select",
+      defaultValue: "plus",
+      valueSources: ["value"],
+      mainWidgetProps: {
+        customProps: {
+          showSearch: false
+        }
+      },
+      fieldSettings: {
+        listValues: {
+          plus: "+",
+          minus: "-",
+        },
+      }
+    },
+    val: {
+      label: "Value",
+      type: "number",
+      fieldSettings: {
+        min: 0,
+      },
+      defaultValue: 1,
+      valueSources: ["value"],
+    },
+    dim: {
+      label: "Dimention",
+      type: "select",
+      defaultValue: "day",
+      valueSources: ["value"],
+      mainWidgetProps: {
+        customProps: {
+          showSearch: false
+        }
+      },
+      fieldSettings: {
+        listValues: {
+          day: "day",
+          week: "week",
+          month: "month",
+          year: "year",
+        },
+      }
+    },
+  }
+};
+
+const LOWER = {
+  label: "Lowercase",
+  mongoFunc: "$toLower",
+  jsonLogic: "toLowerCase",
+  //jsonLogicIsMethod: true, // Removed in JsonLogic 2.x due to Prototype Pollution
+  returnType: "text",
+  args: {
+    str: {
+      label: "String",
+      type: "text",
+      valueSources: ["value", "field"],
+    },
+  }
+};
+
+const LINEAR_REGRESSION = {
+  label: "Linear regression",
+  returnType: "number",
+  formatFunc: ({coef, bias, val}, _) => `(${coef} * ${val} + ${bias})`,
+  sqlFormatFunc: ({coef, bias, val}) => `(${coef} * ${val} + ${bias})`,
+  mongoFormatFunc: ({coef, bias, val}) => ({"$sum": [{"$multiply": [coef, val]}, bias]}),
+  jsonLogic: ({coef, bias, val}) => ({ "+": [ {"*": [coef, val]}, bias ] }),
+  /* eslint-disable */
+  jsonLogicImport: (v) => {
+    const coef = v["+"][0]["*"][0];
+    const val = v["+"][0]["*"][1];
+    const bias = v["+"][1];
+    return [coef, val, bias];
+  },
+  /* eslint-enable */
+  renderBrackets: ["", ""],
+  renderSeps: [" * ", " + "],
+  args: {
+    coef: {
+      label: "Coef",
+      type: "number",
+      defaultValue: 1,
+      valueSources: ["value"],
+    },
+    val: {
+      label: "Value",
+      type: "number",
+      valueSources: ["value"],
+    },
+    bias: {
+      label: "Bias",
+      type: "number",
+      defaultValue: 0,
+      valueSources: ["value"],
+    }
+  }
+};
+
+export {
+  RELATIVE_DATE,
+  LINEAR_REGRESSION,
+  LOWER,
+};

--- a/modules/export/mongoDb.js
+++ b/modules/export/mongoDb.js
@@ -365,6 +365,9 @@ const formatFunc = (meta, config, currentValue, parentPath) => {
       formattedArgs,
     ];
     ret = fn(...args);
+  } else if (funcConfig.mongoFormatFunc === null) {
+    meta.errors.push(`Functon ${funcName} is not supported`);
+    return [undefined, false];
   } else {
     if (mongoArgsAsObject)
       ret = { [funcName]: formattedArgs };

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -241,7 +241,7 @@ const convertFunc = (op, vals, conv, config, not, fieldConfig, meta, parentField
 
   if (funcKey) {
     const funcConfig = config.funcs[funcKey];
-    const argKeys = Object.keys(funcConfig.args);
+    const argKeys = Object.keys(funcConfig.args || {});
     let args = argsArr.reduce((acc, val, ind) => {
       const argKey = argKeys[ind];
       const argConfig = funcConfig.args[argKey];

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -841,4 +841,5 @@ export const Utils: Utils;
 export const Query: Query;
 export const Builder: Builder;
 export const BasicConfig: BasicConfig;
+export const BasicFuncs: Funcs;
 export const Widgets: ReadyWidgets;

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -677,6 +677,7 @@ export interface Func {
 }
 export interface FuncArg extends ValueField {
   isOptional?: boolean,
+  showPrefix?: boolean,
 }
 export type Funcs = TypedMap<Func | FuncGroup>;
 

--- a/modules/index.js
+++ b/modules/index.js
@@ -6,8 +6,9 @@ import * as Import from "./import";
 import * as Widgets from "./components/widgets/index";
 import * as Operators from "./components/operators";
 import * as BasicUtils from "./utils";
+import * as BasicFuncs from "./config/funcs";
 const Utils = {...BasicUtils, ...Export, ...Import};
-export {Widgets, Operators, Utils, Export, Import};
+export {Widgets, Operators, Utils, Export, Import, BasicFuncs};
 
 export {default as BasicConfig} from "./config/basic";
 

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -315,7 +315,7 @@ export const getOperatorConfig = (config, operator, field = null) => {
 };
 
 export const getFieldWidgetConfig = (config, field, operator, widget = null, valueSrc = null) => {
-  if (!field || !(operator || widget))
+  if (!field || !(operator || widget) && valueSrc != "const")
     return null;
   const fieldConfig = getFieldConfig(config, field);
   if (!widget)

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -134,12 +134,15 @@ function _extendFieldConfig(fieldConfig, config, path = null, isFuncArg = false)
 
     if (!fieldConfig.widgets)
       fieldConfig.widgets = {};
+    if (isFuncArg)
+      fieldConfig._isFuncArg = true;
     fieldConfig.mainWidget = fieldConfig.mainWidget || typeConfig.mainWidget;
     fieldConfig.valueSources = fieldConfig.valueSources || typeConfig.valueSources;
     for (let widget in typeConfig.widgets) {
       let fieldWidgetConfig = fieldConfig.widgets[widget] || {};
       const typeWidgetConfig = typeConfig.widgets[widget] || {};
       if (!isFuncArg) {
+        //todo: why I've excluded isFuncArg ?
         const shouldIncludeOperators = fieldConfig.preferWidgets && (widget == "field" || fieldConfig.preferWidgets.includes(widget)) || excludeOperators.length > 0;
         if (fieldWidgetConfig.operators) {
           if (!operators)
@@ -315,7 +318,9 @@ export const getOperatorConfig = (config, operator, field = null) => {
 };
 
 export const getFieldWidgetConfig = (config, field, operator, widget = null, valueSrc = null) => {
-  if (!field || !(operator || widget) && valueSrc != "const")
+  if (!field)
+    return null;
+  if (!(operator || widget) && valueSrc != "const")
     return null;
   const fieldConfig = getFieldConfig(config, field);
   if (!widget)

--- a/modules/utils/funcUtils.js
+++ b/modules/utils/funcUtils.js
@@ -50,7 +50,7 @@ export const completeFuncValue = (value, config) => {
           return undefined;
         }
       } else if (argConfig.defaultValue !== undefined) {
-        complValue = complValue.setIn(["args", argKey, "value"], argConfig.defaultValue);
+        complValue = complValue.setIn(["args", argKey, "value"], getDefaultArgValue(argConfig));
         complValue = complValue.setIn(["args", argKey, "valueSrc"], "value");
       } else if (argConfig.isOptional) {
         // optional
@@ -121,12 +121,25 @@ export const setFunc = (value, funcKey, config) => {
   if (funcConfig) {
     for (const argKey in funcConfig.args) {
       const argConfig = funcConfig.args[argKey];
+      const argDefaultValueSrc = argConfig.valueSources.length ? argConfig.valueSources[0] : undefined;
+      if (argDefaultValueSrc) {
+        value = value.setIn(["args", argKey, "valueSrc"], argDefaultValueSrc);
+      }
       if (argConfig.defaultValue !== undefined) {
-        value = value.setIn(["args", argKey, "value"], argConfig.defaultValue);
+        value = value.setIn(["args", argKey, "value"], getDefaultArgValue(argConfig));
       }
     }
   }
 
+  return value;
+};
+
+const getDefaultArgValue = ({defaultValue: value}) => {
+  if (typeof value == "object" && !Immutable.Map.isMap(value) && value.func) {
+    return Immutable.fromJS(value, function (k, v) {
+      return Immutable.Iterable.isIndexed(v) ? v.toList() : v.toOrderedMap();
+    });
+  }
   return value;
 };
 

--- a/modules/utils/ruleUtils.js
+++ b/modules/utils/ruleUtils.js
@@ -278,7 +278,7 @@ function _getWidgetsAndSrcsForFieldOp (config, field, operator = null, valueSrc 
         canAdd = canAdd && (valueSrc != "value" || isFuncArg); //if can't check operators, don't add
       if (widgetConfig.operators && operator)
         canAdd = canAdd && widgetConfig.operators.indexOf(operator) != -1;
-      if (valueSrc && valueSrc != widgetValueSrc)
+      if (valueSrc && valueSrc != widgetValueSrc && valueSrc != "const")
         canAdd = false;
       if (opConfig && opConfig.cardinality == 0 && (widgetValueSrc != "value"))
         canAdd = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/tests/specs/QueryWithSubquery.test.js
+++ b/tests/specs/QueryWithSubquery.test.js
@@ -21,10 +21,10 @@ describe("query with subquery and datetime types", () => {
       "mongo": {
         "$or": [
           {
-            "datetime": "2020-05-18 21:50:01"
+            "datetime": "2020-05-18T21:50:01.000Z"
           }, {
-            "date": "2020-05-18",
-            "time": "00:50:00"
+            "date": "2020-05-18T00:00:00.000Z",
+            "time": 3000
           }
         ]
       },

--- a/tests/specs/WidgetsAntd.test.js
+++ b/tests/specs/WidgetsAntd.test.js
@@ -262,7 +262,7 @@ describe("antdesign widgets interactions", () => {
           "queryHuman": "Date BETWEEN \"10.05.2020\" AND \"15.05.2020\"",
           "sql": "date BETWEEN '2020-05-10' AND '2020-05-15'",
           "mongo": {
-            "date": { "$gte": "2020-05-10", "$lte": "2020-05-15" }
+            "date": { "$gte": "2020-05-10T00:00:00.000Z", "$lte": "2020-05-15T00:00:00.000Z" }
           },
           "logic": {
             "and": [ { "<=": [ "2020-05-10T00:00:00.000Z", { "var": "date" }, "2020-05-15T00:00:00.000Z" ] } ]


### PR DESCRIPTION
Resolves https://github.com/ukrbublik/react-awesome-query-builder/issues/435

todo:
- [ ] document option `jsonLogicCustomOps`
- [ ] add util to return all used custom ops to be added by user with `jsonLogic.add_operation`
- [ ] format SQL of different dialects?
- [ ] support RELATIVE_DATETIME for mongo?
