### PR TITLE
Import complex function from Jsonlogic

### DIFF
--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -662,6 +662,7 @@ To enable this feature set `valueSources` of type to `['value', 'func']` (see be
 |mongoArgsAsObject | |false |Some functions like https://docs.mongodb.com/manual/reference/operator/aggregation/rtrim/[$rtrim] supports named args, other ones like https://docs.mongodb.com/manual/reference/operator/aggregation/slice/[$slice] takes args as array
 |mongoFormatFunc |- for MongoDB format | |Can be used instead of `mongoFunc`. Function with 1 param - args object `{<arg name> : <arg value>}`, should return formatted function expression object.
 |jsonLogic |+ for http://jsonlogic.com[JsonLogic] | |String (function name) or function with 1 param - args object `{<arg name> : <arg value>}`, should return formatted function expression for JsonLogic.
+|jsonLogicImport | | |Function to convert given JsonLogic expression to array of arguments of current function. If given expression can't be parsed into current function, throw an error.
 |args.* | | |Arguments of function. Config is almost same as for simple link:#configfields[fields]
 |args.<arg>.label | |arg's key |Label to be displayed in arg's label or placeholder (if `config.settings.showLabels` is false)
 |args.<arg>.type |+ | |One of types described in link:#configtypes[config.types]

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -515,7 +515,7 @@ export default (skin: string) => {
       label: "Lowercase",
       mongoFunc: "$toLower",
       jsonLogic: "toLowerCase",
-      jsonLogicIsMethod: true,
+      //jsonLogicIsMethod: true, // Removed in JsonLogic 2.x due to Prototype Pollution
       returnType: "text",
       args: {
         str: {

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -532,6 +532,12 @@ export default (skin: string) => {
       sqlFormatFunc: ({coef, bias, val}) => `(${coef} * ${val} + ${bias})`,
       mongoFormatFunc: ({coef, bias, val}) => ({"$sum": [{"$multiply": [coef, val]}, bias]}),
       jsonLogic: ({coef, bias, val}) => ({ "+": [ {"*": [coef, val]}, bias ] }),
+      jsonLogicImport: (v) => {
+        const coef = v["+"][0]["*"][0];
+        const val = v["+"][0]["*"][1];
+        const bias = v["+"][1];
+        return [coef, val, bias];
+      },
       renderBrackets: ["", ""],
       renderSeps: [" * ", " + "],
       args: {

--- a/examples/demo/config.tsx
+++ b/examples/demo/config.tsx
@@ -532,12 +532,14 @@ export default (skin: string) => {
       sqlFormatFunc: ({coef, bias, val}) => `(${coef} * ${val} + ${bias})`,
       mongoFormatFunc: ({coef, bias, val}) => ({"$sum": [{"$multiply": [coef, val]}, bias]}),
       jsonLogic: ({coef, bias, val}) => ({ "+": [ {"*": [coef, val]}, bias ] }),
-      jsonLogicImport: (v) => {
+      /* eslint-disable */
+      jsonLogicImport: (v: any) => {
         const coef = v["+"][0]["*"][0];
         const val = v["+"][0]["*"][1];
         const bias = v["+"][1];
         return [coef, val, bias];
       },
+      /* eslint-enable */
       renderBrackets: ["", ""],
       renderSeps: [" * ", " + "],
       args: {

--- a/examples/demo/init_logic.js
+++ b/examples/demo/init_logic.js
@@ -7,11 +7,10 @@ export default
           "var": "user.login"
         },
         {
-          "method": [
+          "toLowerCase": [
             {
               "var": "user.firstName"
-            },
-            "toLowerCase"
+            }
           ]
         }
       ]

--- a/modules/components/item/Rule.jsx
+++ b/modules/components/item/Rule.jsx
@@ -251,7 +251,7 @@ class Rule extends PureComponent {
     render () {
       const { showOperatorOptions, selectedFieldWidgetConfig } = this.meta;
       const { valueSrc, value } = this.props;
-      const canShrinkValue = valueSrc.first() == 'value' && !showOperatorOptions && value.size == 1 && selectedFieldWidgetConfig.fullWidth;
+      const canShrinkValue = valueSrc.first() == "value" && !showOperatorOptions && value.size == 1 && selectedFieldWidgetConfig.fullWidth;
       
       const parts = [
         this.renderField(),

--- a/modules/components/widgets/vanilla/value/VanillaTextArea.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaTextArea.jsx
@@ -17,7 +17,7 @@ export default (props) => {
       onChange={onChange}
       maxLength={maxLength}
       style={{
-        width: fullWidth ? '100%' : undefined
+        width: fullWidth ? "100%" : undefined
       }}
     />
   );

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -515,8 +515,8 @@ const convertOp = (op, vals, conv, config, not, meta, parentField = null) => {
   let {field, fieldConfig, opKey, args, having} = parseRes;
 
   let opConfig = config.operators[opKey];
-  const canRev = !(fieldConfig.type == "!group" && having) && opConfig.reversedOp;
-  if (not && canRev) {
+  const canRev = !(fieldConfig.type == "!group");
+  if (not && canRev && opConfig.reversedOp) {
     not = false;
     opKey = opConfig.reversedOp;
     opConfig = config.operators[opKey];

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -221,7 +221,7 @@ const convertFunc = (op, vals, conv, config, not, fieldConfig, meta, parentField
     funcKey = funcKeys[0];
   } else {
     const v = {[op]: vals};
-    for (const [f, fc] of Object.entries(config.funcs)) {
+    for (const [f, fc] of Object.entries(config.funcs || {})) {
       if (fc.jsonLogicImport && fc.returnType == fieldConfig.type) {
         let parsed;
         try {

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -226,7 +226,9 @@ const convertFunc = (op, vals, conv, config, not, fieldConfig, meta, parentField
         let parsed;
         try {
           parsed = fc.jsonLogicImport(v);
-        } catch(_e) {}
+        } catch(_e) {
+          // given expression `v` can't be parsed into function
+        }
         if (parsed) {
           funcKey = f;
           argsArr = parsed;

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -59,8 +59,13 @@ const buildConv = (config) => {
   let funcs = {};
   for (let funcKey in config.funcs) {
     const funcConfig = config.funcs[funcKey];
-    if (typeof funcConfig.jsonLogic == "string") {
-      const fk = (funcConfig.jsonLogicIsMethod ? "#" : "") + funcConfig.jsonLogic;
+    let fk;
+    if (funcConfig.jsonLogicIsMethod) {
+      fk = "#" + funcConfig.jsonLogic;
+    } else if (typeof funcConfig.jsonLogic == "string") {
+      fk = funcConfig.jsonLogic;
+    }
+    if (fk) {
       if (!funcs[fk])
         funcs[fk] = [];
       funcs[fk].push(funcKey);
@@ -197,7 +202,7 @@ const convertField = (op, vals, conv, config, not, meta, parentField = null) => 
 
 const convertFunc = (op, vals, conv, config, not, fieldConfig, meta, parentField = null) => {
   if (!op) return undefined;
-  let func, argsArr;
+  let func, argsArr, funcKey;
   const jsonLogicIsMethod = (op == "method");
   if (jsonLogicIsMethod) {
     let obj, opts;
@@ -207,20 +212,32 @@ const convertFunc = (op, vals, conv, config, not, fieldConfig, meta, parentField
     func = op;
     argsArr = vals;
   }
-  const fk = (jsonLogicIsMethod ? "#" : "") + func;
 
-  let funcKeys = conv.funcs[fk];
-  if (funcKeys) {
-    let funcKey = funcKeys[0];
-    if (funcKeys.length > 1 && fieldConfig) {
-      funcKeys = funcKeys
-        .filter(k => (config.funcs[k].returnType == fieldConfig.type));
-      if (funcKeys.length == 0) {
-        meta.errors.push(`No funcs returning type ${fieldConfig.type}`);
-        return undefined;
+  const fk = (jsonLogicIsMethod ? "#" : "") + func;
+  const funcKeys = (conv.funcs[fk] || []).filter(k => 
+    (fieldConfig ? config.funcs[k].returnType == fieldConfig.type : true)
+  );
+  if (funcKeys.length) {
+    funcKey = funcKeys[0];
+  } else {
+    const v = {[op]: vals};
+    for (const [f, fc] of Object.entries(config.funcs)) {
+      if (fc.jsonLogicImport && fc.returnType == fieldConfig.type) {
+        let parsed;
+        try {
+          parsed = fc.jsonLogicImport(v);
+        } catch(_e) {}
+        if (parsed) {
+          funcKey = f;
+          argsArr = parsed;
+        }
       }
-      funcKey = funcKeys[0];
     }
+  }
+  if (!funcKey)
+    return undefined;
+
+  if (funcKey) {
     const funcConfig = config.funcs[funcKey];
     const argKeys = Object.keys(funcConfig.args);
     let args = argsArr.reduce((acc, val, ind) => {

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -648,6 +648,7 @@ type SqlFormatFunc = (formattedArgs: { [key: string]: string }) => string;
 type FormatFunc = (formattedArgs: { [key: string]: string }, isForDisplay: boolean) => string;
 type MongoFormatFunc = (formattedArgs: { [key: string]: MongoValue }) => MongoValue;
 type JsonLogicFormatFunc = (formattedArgs: { [key: string]: JsonLogicValue }) => JsonLogicTree;
+type JsonLogicImportFunc = (val: JsonLogicValue) => Array<RuleValue>;
 
 interface FuncGroup {
   type?: "!struct",
@@ -664,6 +665,7 @@ export interface Func {
   mongoArgsAsObject?: boolean,
   jsonLogic?: string | JsonLogicFormatFunc,
   jsonLogicIsMethod?: boolean,
+  jsonLogicImport?: JsonLogicImportFunc,
   formatFunc?: FormatFunc,
   sqlFormatFunc?: SqlFormatFunc,
   mongoFormatFunc?: MongoFormatFunc,

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -664,6 +664,9 @@ export interface Func {
   mongoFunc?: string,
   mongoArgsAsObject?: boolean,
   jsonLogic?: string | JsonLogicFormatFunc,
+  // Deprecated!
+  // Calling methods on objects was remvoed in JsonLogic 2.x
+  // https://github.com/jwadhams/json-logic-js/issues/86
   jsonLogicIsMethod?: boolean,
   jsonLogicImport?: JsonLogicImportFunc,
   formatFunc?: FormatFunc,

--- a/tests/specs/QueryWithFunc.test.js
+++ b/tests/specs/QueryWithFunc.test.js
@@ -26,7 +26,7 @@ describe("query with func", () => {
             "==": [
               { "var": "str" },
               {
-                "method": [ { "var": "str2" },  "toLowerCase" ]
+                "toLowerCase": [ { "var": "str2" } ]
               }
             ]
           }

--- a/tests/support/configs.js
+++ b/tests/support/configs.js
@@ -435,7 +435,6 @@ export const with_funcs = (BasicConfig) => ({
       label: "Lowercase",
       mongoFunc: "$toLower",
       jsonLogic: "toLowerCase",
-      jsonLogicIsMethod: true,
       returnType: "text",
       args: {
         str: {

--- a/tests/support/inits.js
+++ b/tests/support/inits.js
@@ -430,9 +430,8 @@ export const with_func_tolower_from_field = {
     {
       "==": [
         { "var": "str" },
-        { "method": [
-          { "var": "str2" },
-          "toLowerCase"
+        { "toLowerCase": [
+          { "var": "str2" }
         ] }
       ]
     }


### PR DESCRIPTION
- Added `jsonLogicImport` to function config. See [example of usage](https://github.com/ukrbublik/react-awesome-query-builder/pull/443/files#diff-61aa01f2967abb94d710c18d816f98a906f0eefb7d6298fac5c726b67aa6b44eR535)
- Removed `jsonLogicIsMethod` from  function config. "method" has been removed from JsonLogic 2.x due to Prototype Pollution

Also resolves https://github.com/ukrbublik/react-awesome-query-builder/issues/400