### PR TITLE
babel: use "@babel/plugin-transform-runtime"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,8 @@
     "plugins": [
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
         ["@babel/plugin-proposal-class-properties", { "loose": true }],
-        ["@babel/plugin-proposal-private-methods", { "loose": true }]
+        ["@babel/plugin-proposal-private-methods", { "loose": true }],
+        ["@babel/plugin-transform-runtime", { "loose": true }]
     ],
     "env": {
       "production": {


### PR DESCRIPTION
### babel: use "@babel/plugin-transform-runtime" to avoid globally defined regenerator runtime

I've recently encountered this issue while using RAQB: https://stackoverflow.com/questions/65487071/uncaught-referenceerror-regeneratorruntime-is-not-defined-in-react-17-webpack

Although I can import generator runtime in my app, it would be more convenient and clean to avoid it, as documented here: https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator-aliasing

Also I see it slightly reduces the size of RAQB lib folder.