### PR TITLE
Pass  parent item's Id as groupId to each child Item 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - 4.5.3
-  - Added `groupId` (id of the parent Item - Group, RuleGroup, RuleGroup etc) to field's, operartor's and widget's props (PR #510)
+  - Added `groupId` (id of the parent Item - Group, RuleGroup, RuleGroupExt etc) to field's, operartor's and widget's props (PR #510)
   - Fixed export to ES when group is empty (broken 'Clear' button in demo app) (PR #511)
 - 4.5.2
   - Added rule `id` to field's, operartor's and widget's props. Added config of the selected field to the operator props as `fieldConfig` (issue #502) (PR #503)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 - 4.5.3
-  - Added groupIds (id of the parent Item - Group, RuleGroup, RuleGroup etc) to field's, operartor's and widget's props
+  - Added `groupId` (id of the parent Item - Group, RuleGroup, RuleGroup etc) to field's, operartor's and widget's props (PR #510)
+  - Fixed export to ES when group is empty (broken 'Clear' button in demo app) (PR #511)
 - 4.5.2
-  - Added ruleId to field's, operartor's and widget's props. Added config of the selected field to the operatorProps (issue #502)
+  - Added rule `id` to field's, operartor's and widget's props. Added config of the selected field to the operator props as `fieldConfig` (issue #502) (PR #503)
 - 4.5.1
-  - Exported config util functions
+  - Fixed export of field name to ES (broken demo app)
 - 4.5.0
   - Added basic support of export to ElasticSearch (PR #469)
   - Export all helper funcs from configUtils (PR #493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+- 4.5.3
+  - Added groupIds (id of the parent Item - Group, RuleGroup, RuleGroup etc) to field's, operartor's and widget's props
+- 4.5.2
+  - Added ruleId to field's, operartor's and widget's props. Added config of the selected field to the operatorProps (issue #502)
+- 4.5.1
+  - Exported config util functions
 - 4.5.0
   - Added basic support of export to ElasticSearch (PR #469)
   - Export all helper funcs from configUtils (PR #493)
@@ -43,18 +50,18 @@
   - Fixed issue #413 with func arg with 1 value source which is not value
 - 4.0.3
   - Fixed issue #386 with import select field from JsonLogic (reason: bug with func/field widget in getWidgetForFieldOp)
-  - Fixed issue #387 with subgroups in Material UI 
+  - Fixed issue #387 with subgroups in Material UI
 - 4.0.2
   - Fixed MaterialConfig import for TS projects (issue #368)
 - 4.0.1
   - Added custom context to isolate Query Builder store (PR #350)
   - Added support for React 17 as a peer dependency
 - 4.0.0
-  - Removed setting `useGroupsAsArrays`. 
-    Instead added field config `mode` for type `!group` with values: 
-      `some` (default, corresponding useGroupsAsArrays = true), 
-      `array` (new, user can choose one of group operators), 
-      `struct` (obsolete, corresponding useGroupsAsArrays = false).
+  - Removed setting `useGroupsAsArrays`.
+    Instead added field config `mode` for type `!group` with values:
+    `some` (default, corresponding useGroupsAsArrays = true),
+    `array` (new, user can choose one of group operators),
+    `struct` (obsolete, corresponding useGroupsAsArrays = false).
   - For type=`!group` and mode=`array`:
     - new field configs are available: `conjunctions`, `showNot`, `operators`, `defaultOperator`, `initialEmptyWhere`
     - you can use group operators `some`, `none`, `all` or operators with 1 integer opearnd (for count): `equal`, `not_equal`, `less`, `between`, ..
@@ -75,7 +82,7 @@
   - Fixed issue #252 ("Cannot update a component from inside the function body of a different component")
   - Issue #190: Fixed TS def for getTree/2 - added 2nd param light?
 - 2.1.17
-  - Dropped support of loading query in obsolete Immutable string format used in versions 0.* (issue #254)
+  - Dropped support of loading query in obsolete Immutable string format used in versions 0.\* (issue #254)
 - 2.1.16
   - Fixed issues with export to Mongo and JsonLogic of queries with nested groups (#279, #279)
 - 2.1.15
@@ -143,7 +150,7 @@
 - 1.3.7
   - Fixed issue #168 with dot in field name
 - 1.3.6
-  - Added config options to disable inputs: `immutableFieldsMode`, `immutableOpsMode`, `immutableValuesMode` 
+  - Added config options to disable inputs: `immutableFieldsMode`, `immutableOpsMode`, `immutableValuesMode`
 - 1.3.5
   - Issue #158
 - 1.3.3
@@ -156,7 +163,7 @@
   - Added support of `!group`
 - 1.2.0
   - Added `treeselect` and `treemultiselect` types
-  - Changed format of `listValues` from `{<value>: <title>}` to `[{value, title}]` (old is supported). 
+  - Changed format of `listValues` from `{<value>: <title>}` to `[{value, title}]` (old is supported).
     Tree select also use `listValues`, format is compatible with simple select - `[{value, title, parent}]`
 - 1.1.3
   - Fixed console warnings
@@ -207,7 +214,7 @@
   - added: `allowCustomValues` (issue #88)
   - change: removed `renderFieldAndOpAsDropdown`, replaced by `renderField` (issue #109)
   - added `renderOperator` (issue #89)
-  - change: query value now can be exported to JSON (instead of `Immutable.Map`), and loaded with `loadTree`  (old format is supported) (issue #61)
+  - change: query value now can be exported to JSON (instead of `Immutable.Map`), and loaded with `loadTree` (old format is supported) (issue #61)
   - added: `canRegroup`
   - rename: `readonlyMode` -> `immutableGroupsMode`
   - rename: `get_children` -> `renderBuilder`

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -133,7 +133,6 @@ const createGroupContainer = (Group) =>
       // allow removal of the root group.
       const allowFurtherNesting = typeof maxNesting === "undefined" || currentNesting < maxNesting;
       const isRoot = currentNesting == 1;
-      const groupId = isRoot ? this.props.id : this.props.groupId;
       return (
         <div
           className={"group-or-rule-container group-container"}
@@ -143,7 +142,7 @@ const createGroupContainer = (Group) =>
             isDraggingMe ? <Group
               key={"dragging"}
               id={this.props.id}
-              groupId={groupId}
+              groupId={this.props.groupId}
               isDraggingMe={true}
               isDraggingTempo={true}
               dragging={this.props.dragging}
@@ -175,7 +174,7 @@ const createGroupContainer = (Group) =>
             <Group
               key={this.props.id}
               id={this.props.id}
-              groupId={groupId}
+              groupId={this.props.groupId}
               isDraggingMe={isDraggingMe}
               isDraggingTempo={isInDraggingTempo}
               onDragStart={this.props.onDragStart}

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -133,7 +133,7 @@ const createGroupContainer = (Group) =>
       // allow removal of the root group.
       const allowFurtherNesting = typeof maxNesting === "undefined" || currentNesting < maxNesting;
       const isRoot = currentNesting == 1;
-      const groupId = isRoot ? null: this.props.groupId;
+      const groupId = isRoot ? this.props.id : this.props.groupId;
       return (
         <div
           className={"group-or-rule-container group-container"}

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -15,6 +15,7 @@ const createGroupContainer = (Group) =>
       actions: PropTypes.object.isRequired, //{setConjunction: Funciton, removeGroup, addGroup, addRule, ...}
       path: PropTypes.any.isRequired, //instanceOf(Immutable.List)
       id: PropTypes.string.isRequired,
+      groupId: PropTypes.string,
       not: PropTypes.bool,
       conjunction: PropTypes.string,
       children1: PropTypes.any, //instanceOf(Immutable.OrderedMap)

--- a/modules/components/containers/GroupContainer.jsx
+++ b/modules/components/containers/GroupContainer.jsx
@@ -133,7 +133,7 @@ const createGroupContainer = (Group) =>
       // allow removal of the root group.
       const allowFurtherNesting = typeof maxNesting === "undefined" || currentNesting < maxNesting;
       const isRoot = currentNesting == 1;
-
+      const groupId = isRoot ? null: this.props.groupId;
       return (
         <div
           className={"group-or-rule-container group-container"}
@@ -143,6 +143,7 @@ const createGroupContainer = (Group) =>
             isDraggingMe ? <Group
               key={"dragging"}
               id={this.props.id}
+              groupId={groupId}
               isDraggingMe={true}
               isDraggingTempo={true}
               dragging={this.props.dragging}
@@ -174,6 +175,7 @@ const createGroupContainer = (Group) =>
             <Group
               key={this.props.id}
               id={this.props.id}
+              groupId={groupId}
               isDraggingMe={isDraggingMe}
               isDraggingTempo={isInDraggingTempo}
               onDragStart={this.props.onDragStart}

--- a/modules/components/containers/RuleContainer.jsx
+++ b/modules/components/containers/RuleContainer.jsx
@@ -11,6 +11,7 @@ const createRuleContainer = (Rule) =>
   class RuleContainer extends Component {
     static propTypes = {
       id: PropTypes.string.isRequired,
+      groupId: PropTypes.string,
       config: PropTypes.object.isRequired,
       path: PropTypes.any.isRequired, //instanceOf(Immutable.List)
       operator: PropTypes.string,

--- a/modules/components/containers/RuleContainer.jsx
+++ b/modules/components/containers/RuleContainer.jsx
@@ -107,6 +107,7 @@ const createRuleContainer = (Rule) =>
             isDraggingMe ? <Rule
               key={"dragging"}
               id={this.props.id}
+              groupId={this.props.groupId}
               isDraggingMe={true}
               isDraggingTempo={true}
               dragging={this.props.dragging}
@@ -132,6 +133,7 @@ const createRuleContainer = (Rule) =>
             <Rule
               key={this.props.id}
               id={this.props.id}
+              groupId={this.props.groupId}
               isDraggingMe={isDraggingMe}
               isDraggingTempo={isInDraggingTempo}
               onDragStart={this.props.onDragStart}

--- a/modules/components/item/Group.jsx
+++ b/modules/components/item/Group.jsx
@@ -217,7 +217,7 @@ export class BasicGroup extends PureComponent {
         {...this.extraPropsForItem(item)}
         key={item.get("id")}
         id={item.get("id")}
-        groupId={props.id || null}
+        groupId={props.groupId}
         //path={props.path.push(item.get('id'))}
         path={item.get("path")}
         type={type}

--- a/modules/components/item/Group.jsx
+++ b/modules/components/item/Group.jsx
@@ -217,6 +217,7 @@ export class BasicGroup extends PureComponent {
         {...this.extraPropsForItem(item)}
         key={item.get("id")}
         id={item.get("id")}
+        groupId={props.id || null}
         //path={props.path.push(item.get('id'))}
         path={item.get("path")}
         type={type}

--- a/modules/components/item/Group.jsx
+++ b/modules/components/item/Group.jsx
@@ -22,6 +22,7 @@ export class BasicGroup extends PureComponent {
     selectedConjunction: PropTypes.string,
     config: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
+    groupId: PropTypes.string,
     path: PropTypes.any, //instanceOf(Immutable.List)
     children1: PropTypes.any, //instanceOf(Immutable.OrderedMap)
     isDraggingMe: PropTypes.bool,

--- a/modules/components/item/Group.jsx
+++ b/modules/components/item/Group.jsx
@@ -217,7 +217,7 @@ export class BasicGroup extends PureComponent {
         {...this.extraPropsForItem(item)}
         key={item.get("id")}
         id={item.get("id")}
-        groupId={props.groupId}
+        groupId={props.id}
         //path={props.path.push(item.get('id'))}
         path={item.get("path")}
         type={type}

--- a/modules/components/item/Item.jsx
+++ b/modules/components/item/Item.jsx
@@ -16,6 +16,7 @@ const typeMap = {
     <Rule
       {...props.properties.toObject()}
       id={props.id}
+      groupId={props.groupId}
       path={props.path}
       actions={props.actions}
       reordableNodesCnt={props.reordableNodesCnt}
@@ -46,6 +47,7 @@ const typeMap = {
     <RuleGroup 
       {...props.properties.toObject()}
       id={props.id}
+      groupId={props.groupId}
       path={props.path}
       actions={props.actions}
       config={props.config}
@@ -62,6 +64,7 @@ const typeMap = {
     <RuleGroupExt 
       {...props.properties.toObject()}
       id={props.id}
+      groupId={props.groupId}
       path={props.path}
       actions={props.actions}
       config={props.config}
@@ -82,6 +85,7 @@ class Item extends PureComponent {
     //tree: PropTypes.instanceOf(Immutable.Map).isRequired,
     config: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
+    groupId: PropTypes.string,
     type: PropTypes.oneOf(types).isRequired,
     path: PropTypes.any.isRequired, //instanceOf(Immutable.List)
     properties: PropTypes.any.isRequired, //instanceOf(Immutable.Map)

--- a/modules/components/item/Item.jsx
+++ b/modules/components/item/Item.jsx
@@ -31,6 +31,7 @@ const typeMap = {
     <Group 
       {...props.properties.toObject()}
       id={props.id}
+      groupId={props.groupId}
       path={props.path}
       actions={props.actions}
       config={props.config}

--- a/modules/components/item/Rule.jsx
+++ b/modules/components/item/Rule.jsx
@@ -18,6 +18,8 @@ const classNames = require("classnames");
 @ConfirmFn
 class Rule extends PureComponent {
     static propTypes = {
+      id: PropTypes.string.isRequired,
+      groupId: PropTypes.string,
       selectedField: PropTypes.string,
       selectedOperator: PropTypes.string,
       operatorOptions: PropTypes.object,

--- a/modules/components/item/Rule.jsx
+++ b/modules/components/item/Rule.jsx
@@ -143,6 +143,7 @@ class Rule extends PureComponent {
         selectedFieldWidgetConfig={selectedFieldWidgetConfig}
         readonly={immutableOpsMode}
         id={this.props.id}
+        groupId={this.props.groupId}
       />;
     }
 
@@ -166,6 +167,7 @@ class Rule extends PureComponent {
         setValueSrc={!immutableValuesMode ? this.props.setValueSrc : dummyFn}
         readonly={immutableValuesMode}
         id={this.props.id}
+        groupId={this.props.groupId}
       />;
 
       return (

--- a/modules/components/item/Rule.jsx
+++ b/modules/components/item/Rule.jsx
@@ -120,6 +120,7 @@ class Rule extends PureComponent {
         parentField={this.props.parentField}
         readonly={immutableFieldsMode}
         id={this.props.id}
+        groupId={this.props.groupId}
       />;
     }
 

--- a/modules/components/item/RuleGroup.jsx
+++ b/modules/components/item/RuleGroup.jsx
@@ -64,6 +64,8 @@ class RuleGroup extends BasicGroup {
       setField={this.props.setField}
       parentField={this.props.parentField}
       readonly={immutableFieldsMode}
+      id={this.props.id}
+      groupId={this.props.groupId}
     />;
   }
 

--- a/modules/components/item/RuleGroupExt.jsx
+++ b/modules/components/item/RuleGroupExt.jsx
@@ -106,6 +106,8 @@ class RuleGroupExt extends BasicGroup {
       setField={this.props.setField}
       parentField={this.props.parentField}
       readonly={immutableFieldsMode}
+      id={this.props.id}
+      groupId={this.props.groupId}
     />;
   }
 
@@ -130,6 +132,8 @@ class RuleGroupExt extends BasicGroup {
       showOperatorLabel={showOperatorLabel}
       selectedFieldWidgetConfig={selectedFieldWidgetConfig}
       readonly={immutableFieldsMode}
+      id={this.props.id}
+      groupId={this.props.groupId}
     />;
   }
 
@@ -152,6 +156,8 @@ class RuleGroupExt extends BasicGroup {
       setValue={!immutableValuesMode ? this.props.setValue : dummyFn}
       setValueSrc={dummyFn}
       readonly={immutableValuesMode}
+      id={this.props.id}
+      groupId={this.props.groupId}
     />;
 
     return (

--- a/modules/components/rule/Field.jsx
+++ b/modules/components/rule/Field.jsx
@@ -10,6 +10,8 @@ import keys from "lodash/keys";
 
 export default class Field extends PureComponent {
     static propTypes = {
+      id: PropTypes.string,
+      groupId: PropTypes.string,
       config: PropTypes.object.isRequired,
       selectedField: PropTypes.string,
       parentField: PropTypes.string,

--- a/modules/components/rule/Field.jsx
+++ b/modules/components/rule/Field.jsx
@@ -124,7 +124,7 @@ export default class Field extends PureComponent {
     }
 
     render() {
-      const {config, customProps, setField, readonly,id, groupId} = this.props;
+      const {config, customProps, setField, readonly, id, groupId} = this.props;
       const {renderField} = config.settings;
       const renderProps = {
         id,

--- a/modules/components/rule/Field.jsx
+++ b/modules/components/rule/Field.jsx
@@ -122,10 +122,11 @@ export default class Field extends PureComponent {
     }
 
     render() {
-      const {config, customProps, setField, readonly,id} = this.props;
+      const {config, customProps, setField, readonly,id, groupId} = this.props;
       const {renderField} = config.settings;
       const renderProps = {
         id,
+        groupId,
         config, 
         customProps, 
         readonly,

--- a/modules/components/rule/FieldWrapper.jsx
+++ b/modules/components/rule/FieldWrapper.jsx
@@ -5,7 +5,7 @@ import {Col} from "../utils";
 
 export default class FieldWrapper extends PureComponent {
   render() {
-    const {config, selectedField, setField, parentField, classname, readonly,id,groupId} = this.props;
+    const {config, selectedField, setField, parentField, classname, readonly, id, groupId} = this.props;
     return (
       <Col className={classname}>
         { config.settings.showLabels

--- a/modules/components/rule/FieldWrapper.jsx
+++ b/modules/components/rule/FieldWrapper.jsx
@@ -5,7 +5,7 @@ import {Col} from "../utils";
 
 export default class FieldWrapper extends PureComponent {
   render() {
-    const {config, selectedField, setField, parentField, classname, readonly,id} = this.props;
+    const {config, selectedField, setField, parentField, classname, readonly,id,groupId} = this.props;
     return (
       <Col className={classname}>
         { config.settings.showLabels
@@ -19,6 +19,7 @@ export default class FieldWrapper extends PureComponent {
           customProps={config.settings.customFieldSelectProps}
           readonly={readonly}
           id={id}
+          groupId={groupId}
         />
       </Col>
     );

--- a/modules/components/rule/FuncSelect.jsx
+++ b/modules/components/rule/FuncSelect.jsx
@@ -14,6 +14,8 @@ import clone from "clone";
 
 export default class FuncSelect extends PureComponent {
   static propTypes = {
+    id: PropTypes.string,
+    groupId: PropTypes.string,
     config: PropTypes.object.isRequired,
     field: PropTypes.string.isRequired,
     operator: PropTypes.string,
@@ -174,7 +176,7 @@ export default class FuncSelect extends PureComponent {
   }
 
   render() {
-    const {config, customProps, setValue, readonly} = this.props;
+    const {config, customProps, setValue, readonly, id, groupId} = this.props;
     const {renderFunc} = config.settings;
     const renderProps = {
       config,
@@ -182,6 +184,8 @@ export default class FuncSelect extends PureComponent {
       readonly,
       setField: setValue,
       items: this.items,
+      id,
+      groupId,
       ...this.meta
     };
     return renderFunc(renderProps);

--- a/modules/components/rule/FuncWidget.jsx
+++ b/modules/components/rule/FuncWidget.jsx
@@ -12,6 +12,8 @@ import {useOnPropsChanged} from "../../utils/reactUtils";
 
 export default class FuncWidget extends PureComponent {
   static propTypes = {
+    id: PropTypes.string,
+    groupId: PropTypes.string,
     config: PropTypes.object.isRequired,
     field: PropTypes.string.isRequired,
     operator: PropTypes.string,
@@ -69,12 +71,13 @@ export default class FuncWidget extends PureComponent {
   };
 
   renderFuncSelect = () => {
-    const {config, field, operator, customProps, value, readonly, parentFuncs} = this.props;
+    const {config, field, operator, customProps, value, readonly, parentFuncs, id, groupId} = this.props;
     const funcKey = value ? value.get("func") : null;
     const selectProps = {
       value: funcKey,
       setValue: this.setFunc,
       config, field, operator, customProps, readonly, parentFuncs,
+      id, groupId,
     };
     const {showLabels, funcLabel} = config.settings;
     const widgetLabel = showLabels
@@ -116,7 +119,7 @@ export default class FuncWidget extends PureComponent {
   };
 
   renderArgVal = (funcKey, argKey, argDefinition) => {
-    const {config, field, operator, value, readonly, parentFuncs} = this.props;
+    const {config, field, operator, value, readonly, parentFuncs, id, groupId} = this.props;
     const arg = value ? value.getIn(["args", argKey]) : null;
     const argVal = arg ? arg.get("value") : undefined;
     const defaultValueSource = argDefinition.valueSources.length == 1 ? argDefinition.valueSources[0] : undefined;
@@ -137,6 +140,8 @@ export default class FuncWidget extends PureComponent {
       argDefinition,
       readonly,
       parentFuncs,
+      id,
+      groupId,
     };
     //tip: value & valueSrc will be converted to Immutable.List at <Widget>
 
@@ -215,6 +220,8 @@ class ArgWidget extends PureComponent {
     setValueSrc: PropTypes.func.isRequired,
     readonly: PropTypes.bool,
     parentFuncs: PropTypes.array,
+    id: PropTypes.string,
+    groupId: PropTypes.string,
   };
 
   setValue = (_delta, value, _widgetType) => {

--- a/modules/components/rule/Operator.jsx
+++ b/modules/components/rule/Operator.jsx
@@ -60,7 +60,7 @@ export default class Operator extends PureComponent {
     
     return {
       placeholder, items,
-      selectedKey, selectedKeys, selectedPath, selectedLabel, selectedOpts,fieldConfig
+      selectedKey, selectedKeys, selectedPath, selectedLabel, selectedOpts, fieldConfig
     };
   }
 

--- a/modules/components/rule/Operator.jsx
+++ b/modules/components/rule/Operator.jsx
@@ -9,6 +9,8 @@ import {useOnPropsChanged} from "../../utils/reactUtils";
 
 export default class Operator extends PureComponent {
   static propTypes = {
+    id: PropTypes.string,
+    groupId: PropTypes.string,
     config: PropTypes.object.isRequired,
     selectedField: PropTypes.string,
     selectedOperator: PropTypes.string,
@@ -78,10 +80,11 @@ export default class Operator extends PureComponent {
   }
 
   render() {
-    const {config, customProps, setOperator, readonly,id} = this.props;
+    const {config, customProps, setOperator, readonly, id, groupId} = this.props;
     const {renderOperator} = config.settings;
     const renderProps = {
       id,
+      groupId,
       config, 
       customProps, 
       readonly,

--- a/modules/components/rule/OperatorWrapper.jsx
+++ b/modules/components/rule/OperatorWrapper.jsx
@@ -7,7 +7,7 @@ export default class OperatorWrapper extends PureComponent {
   render() {
     const {
       config, selectedField, selectedOperator, setOperator, 
-      selectedFieldPartsLabels, showOperator, showOperatorLabel, selectedFieldWidgetConfig, readonly,id, groupId
+      selectedFieldPartsLabels, showOperator, showOperatorLabel, selectedFieldWidgetConfig, readonly, id, groupId
     } = this.props;
     const operator = showOperator
             && <Col key={"operators-for-"+(selectedFieldPartsLabels || []).join("_")} className="rule--operator">

--- a/modules/components/rule/OperatorWrapper.jsx
+++ b/modules/components/rule/OperatorWrapper.jsx
@@ -7,7 +7,7 @@ export default class OperatorWrapper extends PureComponent {
   render() {
     const {
       config, selectedField, selectedOperator, setOperator, 
-      selectedFieldPartsLabels, showOperator, showOperatorLabel, selectedFieldWidgetConfig, readonly,id
+      selectedFieldPartsLabels, showOperator, showOperatorLabel, selectedFieldWidgetConfig, readonly,id, groupId
     } = this.props;
     const operator = showOperator
             && <Col key={"operators-for-"+(selectedFieldPartsLabels || []).join("_")} className="rule--operator">
@@ -22,6 +22,7 @@ export default class OperatorWrapper extends PureComponent {
                 setOperator={setOperator}
                 readonly={readonly}
                 id={id}
+                groupId={groupId}
               />
             </Col>;
     const hiddenOperator = showOperatorLabel

--- a/modules/components/rule/ValueField.jsx
+++ b/modules/components/rule/ValueField.jsx
@@ -12,6 +12,8 @@ import clone from "clone";
 
 export default class ValueField extends PureComponent {
   static propTypes = {
+    id: PropTypes.string,
+    groupId: PropTypes.string,
     setValue: PropTypes.func.isRequired,
     config: PropTypes.object.isRequired,
     field: PropTypes.string.isRequired,
@@ -183,7 +185,7 @@ export default class ValueField extends PureComponent {
   }
 
   render() {
-    const {config, customProps, setValue, readonly} = this.props;
+    const {config, customProps, setValue, readonly, id, groupId} = this.props;
     const {renderField} = config.settings;
     const renderProps = {
       config,
@@ -191,6 +193,8 @@ export default class ValueField extends PureComponent {
       setField: setValue,
       readonly,
       items: this.items,
+      id,
+      groupId,
       ...this.meta
     };
     return renderField(renderProps);

--- a/modules/components/rule/Widget.jsx
+++ b/modules/components/rule/Widget.jsx
@@ -27,6 +27,7 @@ export default class Widget extends PureComponent {
     readonly: PropTypes.bool,
     asyncListValues: PropTypes.array,
     id: PropTypes.string,
+    groupId: PropTypes.string,
     //actions
     setValue: PropTypes.func,
     setValueSrc: PropTypes.func,
@@ -172,7 +173,7 @@ export default class Widget extends PureComponent {
   }
 
   renderWidget = (delta, meta, props) => {
-    const {config, isFuncArg, leftField, operator, value: values, valueError, readonly, parentField, parentFuncs, id} = props;
+    const {config, isFuncArg, leftField, operator, value: values, valueError, readonly, parentField, parentFuncs, id, groupId} = props;
     const {settings} = config;
     const { widgets, iValues, aField } = meta;
     const value = isFuncArg ? iValues : values;
@@ -188,6 +189,7 @@ export default class Widget extends PureComponent {
         {valueSrc == "func" ? null : widgetLabel}
         <WidgetFactory
           id={id}
+          groupId={groupId}
           valueSrc={valueSrc}
           delta={delta}
           value={value}

--- a/modules/components/rule/WidgetFactory.jsx
+++ b/modules/components/rule/WidgetFactory.jsx
@@ -6,7 +6,7 @@ export default ({
   value: immValue, valueError: immValueError, asyncListValues,
   isSpecialRange, fieldDefinition,
   widget, widgetDefinition, widgetValueLabel, valueLabels, textSeparators, setValueHandler,
-  config, field, operator, readonly, parentField, parentFuncs, id
+  config, field, operator, readonly, parentField, parentFuncs, id, groupId
 }) => {
   const {factory: widgetFactory, ...fieldWidgetProps} = widgetDefinition;
   const isConst = isFuncArg && fieldDefinition.valueSources && fieldDefinition.valueSources.length == 1 && fieldDefinition.valueSources[0] == "const";
@@ -45,7 +45,7 @@ export default ({
     setValue: setValueHandler,
     readonly: readonly,
     asyncListValues: asyncListValues,
-    id,
+    id, groupId
   });
     
   if (widget == "field") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",


### PR DESCRIPTION
Following issue https://github.com/ukrbublik/react-awesome-query-builder/issues/502, passing some more useful data down the props

Summary:
Group: if root - gets groupId null, otherwise - from parent Group
RuleGroup: gets groupId from parent Group
Rule: gets groupId from Group, RuleGroup or RuleGroupExt

id and groupId passed down till they reach  Field, Operator, Widget

