### PR TITLE
Updated type of Utils.queryString

### DIFF
--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -103,7 +103,7 @@ export interface Utils {
   // export
   jsonLogicFormat(tree: ImmutableTree, config: Config): JsonLogicResult;
   queryBuilderFormat(tree: ImmutableTree, config: Config): Object;
-  queryString(tree: ImmutableTree, config: Config, isForDisplay?: boolean): string;
+  queryString(tree: ImmutableTree, config: Config, isForDisplay?: boolean): string | undefined;
   sqlFormat(tree: ImmutableTree, config: Config): string;
   mongodbFormat(tree: ImmutableTree, config: Config): Object;
   elasticSearchFormat(tree: ImmutableTree, config: Config): Object;


### PR DESCRIPTION
Can return undefined as well as string.