### PR TITLE
add null operators

### DIFF
--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -83,6 +83,8 @@ const {
         ends_with,
         between,
         not_between,
+        is_null,
+        is_not_null,
         is_empty,
         is_not_empty,
         select_equals, // like `equal`, but for select

--- a/modules/config/antd/index.js
+++ b/modules/config/antd/index.js
@@ -179,6 +179,8 @@ const types = {
           "not_between",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
       }
     },

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -311,6 +311,31 @@ const operators = {
     jsonLogic: "!!",
     elasticSearchQueryType: "exists",
   },
+  is_null: {
+    label: "Is null",
+    labelForFormat: "IS NULL",
+    sqlOp: "IS NULL",
+    cardinality: 0,
+    reversedOp: "is_not_null",
+    formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
+      return isForDisplay ? `${field} IS NULL` : `!${field}`;
+    },
+    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
+    jsonLogic: "!"
+  },
+  is_not_null: {
+    label: "Is not null",
+    labelForFormat: "IS NOT NULL",
+    sqlOp: "IS NOT NULL",
+    cardinality: 0,
+    reversedOp: "is_null",
+    formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
+      return isForDisplay ? `${field} IS NOT NULL` : `!!${field}`;
+    },
+    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
+    jsonLogic: "!!",
+    elasticSearchQueryType: "exists",
+  },
   select_equals: {
     label: "==",
     labelForFormat: "==",
@@ -768,6 +793,8 @@ const types = {
           "not_equal",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
           "like",
           "not_like",
           "starts_with",
@@ -783,6 +810,8 @@ const types = {
           "not_equal",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
           "like",
           "not_like",
           "starts_with",
@@ -817,6 +846,8 @@ const types = {
           "not_between",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
       },
       slider: {
@@ -829,6 +860,8 @@ const types = {
           "greater_or_equal",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null"
         ],
       },
     },
@@ -847,7 +880,9 @@ const types = {
           "between",
           "not_between",
           "is_empty",
-          "is_not_empty"
+          "is_not_empty",
+          "is_null",
+          "is_not_null"
         ]
       }
     },
@@ -867,6 +902,8 @@ const types = {
           "not_between",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ]
       }
     },
@@ -886,6 +923,8 @@ const types = {
           "not_between",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
       }
     },
@@ -900,6 +939,8 @@ const types = {
           "select_not_equals",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
         widgetProps: {
           customProps: {
@@ -913,6 +954,8 @@ const types = {
           "select_not_any_in",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
       },
     },
@@ -926,6 +969,8 @@ const types = {
           "multiselect_not_equals",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ]
       }
     },
@@ -937,6 +982,8 @@ const types = {
         operators: [
           "equal",
           "not_equal",
+          "is_null",
+          "is_not_null",
         ],
         widgetProps: {
           //you can enable this if you don't use fields as value sources

--- a/modules/config/material/index.js
+++ b/modules/config/material/index.js
@@ -139,6 +139,8 @@ const types = {
           "not_between",
           "is_empty",
           "is_not_empty",
+          "is_null",
+          "is_not_null",
         ],
       }
     },

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -730,6 +730,8 @@ export interface BasicConfig extends Config {
     ends_with: BinaryOperator,
     between: Operator2,
     not_between: Operator2,
+    is_null: UnaryOperator,
+    is_not_null: UnaryOperator,
     is_empty: UnaryOperator,
     is_not_empty: UnaryOperator,
     select_equals: BinaryOperator,


### PR DESCRIPTION
Relates to: #494

This is backwards compatible since we keep `is_empty` operation as is. It has a small caveat when loading tree from jsonlogic. To fix this caveat we would need breaking changes to the `is_empty` operator. 

Changes:
- Add null operators to all types

Todo:
- Add unit tests

Known problems:
- It has the same jsonLogic operator (`!!`) as `is_empty` operator so when using `loadFromJsonLogic()` it is always assigning it the `is_empty` operator. 
