### PR TITLE
Fixed incorrect creation of Map instead of OrderedMap in children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Fix: don't automatically add one rule to query when it become empty when `canLeaveEmptyGroup=true` (issue #504)
   - Added config `forceShowConj` (issue #474)
   - Fixed import of complex hierarchy fields (combination of !group and !struct) from JsonLogic (issues #517, #333)
+  - Fixed non-ordered map bug (issue #501)
 - 4.6.0
   - Added `groupId` (id of the parent Item - Group, RuleGroup, RuleGroupExt etc) to field's, operartor's and widget's props (PR #510)
   - Fixed export to ES when group is empty (broken 'Clear' button in demo app) (PR #511)

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -88,6 +88,13 @@ export const fixPathsInTree = (tree) => {
 
     const children = item.get("children1");
     if (children) {
+      if (children.constructor.name == "Map") {
+        // protect: should me OrderedMap, not Map (issue #501)
+        newTree = newTree.setIn(
+          expandTreePath(itemPath, "children1"), 
+          new Immutable.OrderedMap(children)
+        );
+      }
       children.map((child, _childId) => {
         _processNode(child, itemPath, lev + 1);
       });


### PR DESCRIPTION
Resolves #501
Fixed incorrect creation of Imutable `Map` instead of `OrderedMap` in `children1`