### PR TITLE
Spreading customProps to vanilla widgets

### DIFF
--- a/modules/components/widgets/vanilla/value/VanillaBoolean.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaBoolean.jsx
@@ -2,7 +2,10 @@ import React from "react";
 import uuid from "../../../../utils/uuid";
 
 export default (props) => {
-  const {value, setValue, config, labelYes, labelNo, readonly} = props;
+  const {value, setValue, config, labelYes, labelNo, readonly, customProps = {}} = props;
+  const customRadioYesProps = customProps.radioYes || {};
+  const customRadioNoProps = customProps.radioNo || {};
+
   const onCheckboxChange = e => setValue(e.target.checked);
   const onRadioChange = e => setValue(e.target.value == "true");
   const id = uuid(), id2 = uuid();
@@ -13,9 +16,9 @@ export default (props) => {
   // </>;
 
   return <>
-    <input key={id}  type="radio" id={id} value={true} checked={!!value} disabled={readonly} onChange={onRadioChange} />
+    <input key={id}  type="radio" id={id} value={true} checked={!!value} disabled={readonly} onChange={onRadioChange} { ...customRadioYesProps }/>
     <label style={{display: "inline"}} key={id+"label"}  htmlFor={id}>{labelYes}</label>
-    <input key={id2}  type="radio" id={id2} value={false} checked={!value} disabled={readonly} onChange={onRadioChange} />
+    <input key={id2}  type="radio" id={id2} value={false} checked={!value} disabled={readonly} onChange={onRadioChange} { ...customRadioNoProps } />
     <label style={{display: "inline"}} key={id2+"label"}  htmlFor={id2}>{labelNo}</label>
   </>;
 

--- a/modules/components/widgets/vanilla/value/VanillaDate.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaDate.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import moment from "moment";
 
 export default (props) => {
-  const {value, setValue, config, valueFormat, readonly} = props;
+  const {value, setValue, config, valueFormat, readonly, customProps, } = props;
 
   const onChange = e => {
     let value = e.target.value;
@@ -12,6 +12,6 @@ export default (props) => {
   };
   
   return (
-    <input type="date"  value={value || ""}  disabled={readonly} onChange={onChange} />
+    <input type="date"  value={value || ""}  disabled={readonly} onChange={onChange} {...customProps} />
   );
 };

--- a/modules/components/widgets/vanilla/value/VanillaDateTime.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaDateTime.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import moment from "moment";
 
 export default (props) => {
-  const {value, setValue, config, valueFormat, use12Hours, readonly} = props;
+  const {value, setValue, config, valueFormat, use12Hours, readonly, customProps, } = props;
 
   const onChange = e => {
     let value = e.target.value;
@@ -20,6 +20,6 @@ export default (props) => {
     dtValue = moment(value).format("YYYY-MM-DDTHH:mm");
   
   return (
-    <input type="datetime-local"  value={dtValue}  disabled={readonly} onChange={onChange} />
+    <input type="datetime-local"  value={dtValue}  disabled={readonly} onChange={onChange} {...customProps} />
   );
 };

--- a/modules/components/widgets/vanilla/value/VanillaMultiSelect.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaMultiSelect.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {mapListValues} from "../../../../utils/stuff";
+import omit from "lodash/omit";
 
-export default ({listValues, value, setValue, allowCustomValues, readonly}) => {
+export default ({listValues, value, setValue, allowCustomValues, readonly, customProps,}) => {
   const renderOptions = () => 
     mapListValues(listValues, ({title, value}) => {
       return <option key={value} value={value}>{title}</option>;
@@ -28,6 +29,7 @@ export default ({listValues, value, setValue, allowCustomValues, readonly}) => {
       onChange={onChange}
       value={value}
       disabled={readonly}
+      {...omit(customProps, ["showSearch", "input", "showCheckboxes"])}
     >
       {renderOptions()}
     </select>

--- a/modules/components/widgets/vanilla/value/VanillaNumber.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaNumber.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default (props) => {
-  const {value, setValue, config, readonly, min, max, step, placeholder} = props;
+  const {value, setValue, config, readonly, min, max, step, placeholder, customProps, } = props;
   const onChange = e => {
     let val = e.target.value;
     if (val === "" || val === null)
@@ -12,6 +12,6 @@ export default (props) => {
   };
   const numberValue = value == undefined ? "" : value;
   return (
-    <input type="number"  value={numberValue} placeholder={placeholder} disabled={readonly} min={min} max={max} step={step} onChange={onChange} />
+    <input type="number"  value={numberValue} placeholder={placeholder} disabled={readonly} min={min} max={max} step={step} onChange={onChange} {...customProps} />
   );
 };

--- a/modules/components/widgets/vanilla/value/VanillaSelect.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaSelect.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import {mapListValues} from "../../../../utils/stuff";
+import omit from "lodash/omit";
 
-export default ({listValues, value, setValue, allowCustomValues, readonly}) => {
+export default ({listValues, value, setValue, allowCustomValues, readonly, customProps,}) => {
   const renderOptions = () => 
     mapListValues(listValues, ({title, value}) => {
       return <option key={value} value={value}>{title}</option>;
@@ -15,6 +16,7 @@ export default ({listValues, value, setValue, allowCustomValues, readonly}) => {
       onChange={onChange}
       value={hasValue ? value : ""}
       disabled={readonly}
+      {...omit(customProps, ["showSearch", "input"])}
     >
       {!hasValue && <option disabled value={""}></option>}
       {renderOptions()}

--- a/modules/components/widgets/vanilla/value/VanillaSlider.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaSlider.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default (props) => {
-  const {value, setValue, config, readonly, min, max, step, placeholder} = props;
+  const {value, setValue, config, readonly, min, max, step, placeholder, customProps, } = props;
   const onChange = e => {
     let val = e.target.value;
     if (val === "" || val === null)
@@ -12,8 +12,8 @@ export default (props) => {
   };
   const numberValue = value == undefined ? "" : value;
   return [
-    <input key={"number"} type="number"  value={numberValue} placeholder={placeholder} disabled={readonly} min={min} max={max} step={step} onChange={onChange} />
+    <input key={"number"} type="number"  value={numberValue} placeholder={placeholder} disabled={readonly} min={min} max={max} step={step} onChange={onChange} {...customProps} />
     ,
-    <input key={"range"} type="range"  value={numberValue} disabled={readonly} min={min} max={max} step={step} onChange={onChange} />
+    <input key={"range"} type="range"  value={numberValue} disabled={readonly} min={min} max={max} step={step} onChange={onChange} {...customProps} />
   ];
 };

--- a/modules/components/widgets/vanilla/value/VanillaText.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaText.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default (props) => {
-  const {value, setValue, config, readonly, placeholder, maxLength} = props;
+  const {value, setValue, config, readonly, placeholder, maxLength, customProps, } = props;
   const onChange = e => {
     let val = e.target.value;
     if (val === "")
@@ -17,6 +17,7 @@ export default (props) => {
       disabled={readonly} 
       onChange={onChange}
       maxLength={maxLength}
+      {...customProps}
     />
   );
 };

--- a/modules/components/widgets/vanilla/value/VanillaTextArea.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaTextArea.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default (props) => {
-  const {value, setValue, config, readonly, placeholder, maxLength, maxRows, fullWidth} = props;
+  const {value, setValue, config, readonly, placeholder, maxLength, maxRows, fullWidth, customProps, } = props;
   const onChange = e => {
     let val = e.target.value;
     if (val === "")
@@ -19,6 +19,7 @@ export default (props) => {
       style={{
         width: fullWidth ? "100%" : undefined
       }}
+      {...customProps}
     />
   );
 };

--- a/modules/components/widgets/vanilla/value/VanillaTime.jsx
+++ b/modules/components/widgets/vanilla/value/VanillaTime.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default (props) => {
-  const {value, setValue, config, valueFormat, use12Hours, readonly} = props;
+  const {value, setValue, config, valueFormat, use12Hours, readonly, customProps } = props;
 
   const onChange = e => {
     let value = e.target.value;
@@ -11,6 +11,6 @@ export default (props) => {
   };
   
   return (
-    <input type="time"  value={value || ""}  disabled={readonly} onChange={onChange} />
+    <input type="time"  value={value || ""}  disabled={readonly} onChange={onChange} {...customProps} />
   );
 };


### PR DESCRIPTION
Spreading it like in andt and material widgets to support custom id, data-testid and other props.