### PR TITLE
Fix potential inconsistent order of fields

### DIFF
--- a/modules/components/widgets/antd/core/FieldDropdown.jsx
+++ b/modules/components/widgets/antd/core/FieldDropdown.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import keys from "lodash/keys";
 import { Menu, Dropdown, Tooltip, Button } from "antd";
 const SubMenu = Menu.SubMenu;
 const MenuItem = Menu.Item;
@@ -30,8 +29,7 @@ export default class FieldDropdown extends PureComponent {
   }
 
   renderMenuItems(fields) {
-    return keys(fields).map(fieldKey => {
-      const field = fields[fieldKey];
+    return fields.map(field => {
       const {items, key, path, label, fullLabel, altLabel, tooltip, disabled} = field;
       const pathKey = path || key;
       const option = tooltip ? <Tooltip title={tooltip}>{label}</Tooltip> : label;

--- a/modules/components/widgets/antd/core/FieldSelect.jsx
+++ b/modules/components/widgets/antd/core/FieldSelect.jsx
@@ -3,7 +3,6 @@ import { Tooltip, Select } from "antd";
 import {BUILT_IN_PLACEMENTS, SELECT_WIDTH_OFFSET_RIGHT, calcTextWidth} from "../../../../utils/domUtils";
 import PropTypes from "prop-types";
 const { Option, OptGroup } = Select;
-import keys from "lodash/keys";
 
 
 export default class FieldSelect extends PureComponent {
@@ -79,8 +78,7 @@ export default class FieldSelect extends PureComponent {
   }
 
   renderSelectItems(fields) {
-    return keys(fields).map(fieldKey => {
-      const field = fields[fieldKey];
+    return fields.map(field => {
       const {items, key, path, label, fullLabel, altLabel, tooltip, grouplabel, disabled} = field;
       const pathKey = path || key;
       if (items) {

--- a/modules/components/widgets/antd/core/FieldTreeSelect.jsx
+++ b/modules/components/widgets/antd/core/FieldTreeSelect.jsx
@@ -3,7 +3,6 @@ import { Tooltip, TreeSelect } from "antd";
 import {BUILT_IN_PLACEMENTS, SELECT_WIDTH_OFFSET_RIGHT, calcTextWidth} from "../../../../utils/domUtils";
 import {useOnPropsChanged} from "../../../../utils/reactUtils";
 import PropTypes from "prop-types";
-import keys from "lodash/keys";
 
 
 export default class FieldTreeSelect extends PureComponent {
@@ -46,8 +45,7 @@ export default class FieldTreeSelect extends PureComponent {
   }
 
   getTreeData(fields, fn = null) {
-    return keys(fields).map(fieldKey => {
-      const field = fields[fieldKey];
+    return fields.map(field => {
       const {items, key, path, label, fullLabel, altLabel, tooltip, disabled} = field;
       if (fn)
         fn(field);

--- a/modules/components/widgets/material/core/MaterialFieldSelect.jsx
+++ b/modules/components/widgets/material/core/MaterialFieldSelect.jsx
@@ -6,8 +6,7 @@ import FormControl from "@material-ui/core/FormControl";
 
 export default ({items, setField, selectedKey, readonly, placeholder}) => {
   const renderOptions = (fields, level = 0) => (
-    Object.keys(fields).map(fieldKey => {
-      const field = fields[fieldKey];
+    fields.map(field => {
       const {items, path, label, disabled} = field;
       const prefix = "\u00A0\u00A0".repeat(level);
       if (items) {

--- a/modules/components/widgets/vanilla/core/VanillaFieldSelect.jsx
+++ b/modules/components/widgets/vanilla/core/VanillaFieldSelect.jsx
@@ -2,8 +2,7 @@ import React from "react";
 
 export default ({items, setField, selectedKey, readonly}) => {
   const renderOptions = (fields) => (
-    Object.keys(fields).map(fieldKey => {
-      const field = fields[fieldKey];
+    fields.map(field => {
       const {items, path, label, disabled} = field;
       if (items) {
         return <optgroup disabled={disabled} key={path} label={label}>{renderOptions(items)}</optgroup>;


### PR DESCRIPTION
Resolves #335

Problem:
Iteration of fields was done with `Object.keys` which returns keys in same order as `for..in`
Array iteration with `for..in` does not guarantee correct order, [see official docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#array_iteration_and_for...in)

Solution:
Just use `map` for fields array