### PR TITLE
Improve is_empty and is_null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- 4.9.0
+  - Added `is_null` and `is_not_null` operators (issue #494) (PR #522)
+  - ! Breaking change for operators `is_empty` and `is_not_empty`. Left for text type only, for other types will be auto converted to `is_null`/`is_not_null`. Changed meaning of `is_empty` - now it's just strict comparing with empty string. Before change meaning was similar to `is_null` (and export to SQL was wrong because of non-existent operator `IS EMPTY`). (issue #494)
+  - Fixed order of operators for field when merging operators from 2+ widgets
+  - Added last param `fieldDef` for functions to format operators
 - 4.8.0
   - Added read-only mode switch for rules and groups. See `showLock` and `canDeleteLocked` config options, custom JsonLogic op `locked`, `setLock` action, `lockLabel` and `lockedLabel`. Added Switch components, see `renderSwitch`. (issue #377) (PR #490)
   - Fixed issue with frozen config (`Object.freeze`) by using `clone` (issue #345) (PR #490)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 - 4.9.0
   - Added `is_null` and `is_not_null` operators (issue #494) (PR #522)
-  - ! Breaking change for operators `is_empty` and `is_not_empty`. Left for text type only, for other types will be auto converted to `is_null`/`is_not_null`. Changed meaning of `is_empty` - now it's just strict comparing with empty string. Before change meaning was similar to `is_null` (and export to SQL was wrong because of non-existent operator `IS EMPTY`). (issue #494)
-  - Fixed order of operators for field when merging operators from 2+ widgets
-  - Added last param `fieldDef` for functions to format operators
+  - ! Breaking change for operators `is_empty` and `is_not_empty`. Left for text type only, for other types will be auto converted to `is_null`/`is_not_null`. Changed meaning of `is_empty` - now it's just strict comparing with empty string. Before change meaning was similar to `is_null` (and export to SQL was wrong because of non-existent operator `IS EMPTY`). (issue #494) (PR #573)
+  - Fixed order of operators for field when merging operators from 2+ widgets (PR #573)
+  - Added last param `fieldDef` for functions to format operators (PR #573)
+  - Added `jsonLogic` to widget TS def (PR #572)
 - 4.8.0
   - Added read-only mode switch for rules and groups. See `showLock` and `canDeleteLocked` config options, custom JsonLogic op `locked`, `setLock` action, `lockLabel` and `lockedLabel`. Added Switch components, see `renderSwitch`. (issue #377) (PR #490)
   - Fixed issue with frozen config (`Object.freeze`) by using `clone` (issue #345) (PR #490)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,55 @@
+# Contributing
+
 Feel free to open PRs to fix bugs, add new features, add new reusable types/widgets/operators (eg., regex operator/widget, IP type/widget).  
+
+* [Development](#development)
+  * [Directory structure](#directory-structure) 
+  * [Scripts](#scripts)
+  * [Other UI frameworks](#other-ui-frameworks)
+
+
+## Development
+Clone this repo and run `npm start`. 
+Open `http://localhost:3001/` in a browser. 
+You will see demo app with hot reload of demo code and local library code. 
+
+### Directory structure
+- [`modules`](/modules) - Main source code of library
+  - [`components`](/modules/components) - Core React components
+    - [`widgets`](/modules/components/widgets) - Components to render list of fields, operators, values of different types. Built with UI frameworks
+  - [`config`](/modules/config) - Basic config lives here. See [`CONFIG`](/CONFIG.adoc) docs.
+  - [`export`](/modules/export) - Code for export to JsonLogic, MongoDb, SQL, ElasticSearch, plain string
+  - [`import`](/modules/import) - Code for import from JsonLogic
+  - [`actions`](/modules/actions) - Redux actions
+  - [`stores/tree.js`](/modules/stores/tree.js) - Redux store
+  - [`index.d.ts`](/modules/index.d.ts) - TS definitions
+- [`css`](/css) - Styles for query builder
+- [`examples`](/examples) - Demo app with hot reload of demo code and local library code, uses TS, uses complex config to demonstrate anvanced usage.
+- [`sandbox`](/sandbox) - Demo app with hot reload of only demo code (uses latest version of library from npm), uses TS, uses AntDesign widgets.
+- [`sandbox_simple`](/sandbox_simple) - Demo app with hot reload of only demo code (uses latest version of library from npm), not uses TS, uses vanilla widgets.
+- [`tests`](/tests) - All tests are here. Uses Karma, Mocha, Chai, Enzyme
+
+### Scripts
+- `npm run install-all` - Install npm packages in root, examples, sandboxes. **Required for other scripts!**
+- `npm test` - Run tests with Karma and update coverage. Requires Node.js v10+
+- `npm run lint` - Run ESLint and TSC (in root, tests, examples, sandboxes)
+- `npm run lint-fix` - Run ESLint with `--fix` option (in root, tests, examples, sandboxes)
+- `npm run clean` - Clean all data that can be re-generated (like `node_modules`, `build`, `coverage`)
+- `npm run smoke` - Run tests, lint, build lib, build examples, build sandboxes. Recommended before making PR
+- `npm run build` - Build npm module to `lib`, build minified production package to `build`
+- `npm run build-examples` - Build demo with webpack to `examples/build`
+
+Feel free to open PR to add new reusable types/widgets/operators (eg., regex operator for string, IP type & widget).  
+Pull Requests are always welcomed :)
+
+### Other UI frameworks
+Currently there are 3 collections of widgets:
+- [antdesign widgets](/modules/components/widgets/antd)
+- [material widgets](/modules/components/widgets/material)
+- [vanilla widgets](/modules/components/widgets/vanilla)
+
+Let's say you want to create new collection of Bootstrap widgets to be used in this lib (and submit PR which is always welcomed!).  
+You can use vanilla widgets as skeleton.  
+Then to enable new widgets you need to create config overrides like this:
+[material config](/modules/config/material/index.js)
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [live demo](https://ukrbublik.github.io/react-awesome-query-builder)
   * [Config format](#config-format)
 * [Versions](#versions)
   * [Changelog](#changelog)
+  * [Migration to 4.9.0](#migration-to-490)
   * [Migration from v1 to v2](#migration-from-v1-to-v2)
 * [Development](#development)
   * [Directory structure](#directory-structure) 
@@ -434,6 +435,14 @@ It's recommended to update your version.
 
 ### Changelog
 See [`CHANGELOG`](/CHANGELOG.md)
+
+### Migration to 4.9.0
+Version 4.9.0 has a breaking change for operators `is_empty` and `is_not_empty`. 
+Now these operstors can be used for text type only (for other types they will be auto converted to `is_null`/`is_not_null` during loading of query value created with previous versions). 
+Changed meaning of `is_empty` - now it's just strict comparing with empty string. 
+Before change the meaning was similar to `is_null`. 
+If you used `is_empty` for text types with intention of comparing with null, please replace `is_empty` -> `is_null`, `is_not_empty` -> `is_not_null` in saved query values. 
+If you used JsonLogic for saving, you need to replace `{"!": {"var": "your_field"}}` -> `{"==": [{"var": "your_field"}, null]}` and `{"!!": {"var": "your_field"}}` -> `{"!=": [{"var": "your_field"}, null]}`.
 
 ### Migration from v1 to v2
 From v2.0 of this lib AntDesign is now optional (peer) dependency, so you need to explicitly include `antd` (4.x) in `package.json` of your project if you want to use AntDesign UI.  

--- a/README.md
+++ b/README.md
@@ -39,13 +39,9 @@ See [live demo](https://ukrbublik.github.io/react-awesome-query-builder)
   * [Changelog](#changelog)
   * [Migration to 4.9.0](#migration-to-490)
   * [Migration from v1 to v2](#migration-from-v1-to-v2)
-* [Development](#development)
-  * [Directory structure](#directory-structure) 
-  * [Scripts](#scripts)
-  * [Other UI frameworks](#other-ui-frameworks)
 * [Contributing](#contributing)
-  * [Code Contributors](#code-contributors)
-  * [Financial Contributors](#financial-contributors)
+  * [Code Contributing](#code-contributing)
+  * [Financial Contributing](#financial-contributing)
 
 
 ### Features
@@ -452,61 +448,14 @@ Support of other UI frameworks (like Bootstrap) are planned for future, see [Oth
 
 
 
-## Development
-Clone this repo and run `npm start`. 
-Open `http://localhost:3001/` in a browser. 
-You will see demo app with hot reload of demo code and local library code. 
-
-### Directory structure
-- [`modules`](/modules) - Main source code of library
-  - [`components`](/modules/components) - Core React components
-    - [`widgets`](/modules/components/widgets) - Components to render list of fields, operators, values of different types. Built with UI frameworks
-  - [`config`](/modules/config) - Basic config lives here. See [`CONFIG`](/CONFIG.adoc) docs.
-  - [`export`](/modules/export) - Code for export to JsonLogic, MongoDb, SQL, ElasticSearch, plain string
-  - [`import`](/modules/import) - Code for import from JsonLogic
-  - [`actions`](/modules/actions) - Redux actions
-  - [`stores/tree.js`](/modules/stores/tree.js) - Redux store
-  - [`index.d.ts`](/modules/index.d.ts) - TS definitions
-- [`css`](/css) - Styles for query builder
-- [`examples`](/examples) - Demo app with hot reload of demo code and local library code, uses TS, uses complex config to demonstrate anvanced usage.
-- [`sandbox`](/sandbox) - Demo app with hot reload of only demo code (uses latest version of library from npm), uses TS, uses AntDesign widgets.
-- [`sandbox_simple`](/sandbox_simple) - Demo app with hot reload of only demo code (uses latest version of library from npm), not uses TS, uses vanilla widgets.
-- [`tests`](/tests) - All tests are here. Uses Karma, Mocha, Chai, Enzyme
-
-### Scripts
-- `npm run install-all` - Install npm packages in root, examples, sandboxes. **Required for other scripts!**
-- `npm test` - Run tests with Karma and update coverage. Requires Node.js v10+
-- `npm run lint` - Run ESLint and TSC (in root, tests, examples, sandboxes)
-- `npm run lint-fix` - Run ESLint with `--fix` option (in root, tests, examples, sandboxes)
-- `npm run clean` - Clean all data that can be re-generated (like `node_modules`, `build`, `coverage`)
-- `npm run smoke` - Run tests, lint, build lib, build examples, build sandboxes. Recommended before making PR
-- `npm run build` - Build npm module to `lib`, build minified production package to `build`
-- `npm run build-examples` - Build demo with webpack to `examples/build`
-
-Feel free to open PR to add new reusable types/widgets/operators (eg., regex operator for string, IP type & widget).  
-Pull Requests are always welcomed :)
-
-### Other UI frameworks
-Currently there are 3 collections of widgets:
-- [antdesign widgets](/modules/components/widgets/antd)
-- [material widgets](/modules/components/widgets/material)
-- [vanilla widgets](/modules/components/widgets/vanilla)
-
-Let's say you want to create new collection of Bootstrap widgets to be used in this lib (and submit PR which is always welcomed!).  
-You can use vanilla widgets as skeleton.  
-Then to enable new widgets you need to create config overrides like this:
-[material config](/modules/config/material/index.js)
-
-
-
 ## Contributing
 
-### Code Contributors
+### Code Contributing
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
 <a href="https://github.com/ukrbublik/react-awesome-query-builder/graphs/contributors"><img src="https://opencollective.com/react-awesome-query-builder/contributors.svg?width=890&button=false" /></a>
 
-### Financial Contributors
+### Financial Contributing
 
 Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/react-awesome-query-builder/contribute)]
 

--- a/modules/config/antd/index.js
+++ b/modules/config/antd/index.js
@@ -2,7 +2,7 @@ import en_US from "antd/lib/locale-provider/en_US";
 import AntdWidgets from "../../components/widgets/antd";
 import BasicConfig, {stringifyForDisplay} from "../basic";
 import {getTitleInListValues} from "../../utils/stuff";
-import {SqlString} from "../../utils/sql";
+import {SqlString} from "../../utils/export";
 import React from "react";
 
 

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -373,7 +373,9 @@ const operators = {
         return `${field} IN (${values})`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
-      return `${field} IN (${values.join(", ")})`;
+      if (valueSrc == "value") {
+        return `${field} IN (${values.join(", ")})`;
+      } else return undefined; // not supported
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$in", v => v, false),
     reversedOp: "select_not_any_in",
@@ -392,7 +394,9 @@ const operators = {
         return `${field} NOT IN (${values})`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
-      return `${field} NOT IN (${values.join(", ")})`;
+      if (valueSrc == "value") {
+        return `${field} NOT IN (${values.join(", ")})`;
+      } else return undefined; // not supported
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$nin", v => v, false),
     reversedOp: "select_any_in",

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -177,7 +177,7 @@ const operators = {
     labelForFormat: "Like",
     reversedOp: "not_like",
     sqlOp: "LIKE",
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} LIKE ${values}`;
       } else return undefined; // not supported
@@ -195,7 +195,7 @@ const operators = {
     reversedOp: "like",
     labelForFormat: "Not Like",
     sqlOp: "NOT LIKE",
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} NOT LIKE ${values}`;
       } else return undefined; // not supported
@@ -207,7 +207,7 @@ const operators = {
     label: "Starts with",
     labelForFormat: "Starts with",
     sqlOp: "LIKE",
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} LIKE ${values}`;
       } else return undefined; // not supported
@@ -220,7 +220,7 @@ const operators = {
     label: "Ends with",
     labelForFormat: "Ends with",
     sqlOp: "LIKE",
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} LIKE ${values}`;
       } else return undefined; // not supported
@@ -289,11 +289,18 @@ const operators = {
   is_empty: {
     label: "Is empty",
     labelForFormat: "IS EMPTY",
-    sqlOp: "IS EMPTY",
     cardinality: 0,
     reversedOp: "is_not_empty",
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
-      return isForDisplay ? `${field} IS EMPTY` : `!${field}`;
+      return isForDisplay ? `${field} IS EMPTY` : `${field} IS EMPTY`;
+    },
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
+      if (valueSrc == "value") {
+        if (fieldDef.type == 'text') {
+          return `${field} = ''`;
+        }
+      }
+      return undefined; // not supported
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
     jsonLogic: "!",
@@ -302,11 +309,18 @@ const operators = {
     isNotOp: true,
     label: "Is not empty",
     labelForFormat: "IS NOT EMPTY",
-    sqlOp: "IS NOT EMPTY",
     cardinality: 0,
     reversedOp: "is_empty",
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
-      return isForDisplay ? `${field} IS NOT EMPTY` : `!!${field}`;
+      return isForDisplay ? `${field} IS NOT EMPTY` : `${field} IS NOT EMPTY`;
+    },
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
+      if (valueSrc == "value") {
+        if (fieldDef.type == 'text') {
+          return `${field} <> ''`;
+        }
+      }
+      return undefined; // not supported
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
     jsonLogic: "!!",
@@ -372,7 +386,7 @@ const operators = {
       else
         return `${field} IN (${values})`;
     },
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} IN (${values.join(", ")})`;
       } else return undefined; // not supported
@@ -393,7 +407,7 @@ const operators = {
       else
         return `${field} NOT IN (${values})`;
     },
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value") {
         return `${field} NOT IN (${values.join(", ")})`;
       } else return undefined; // not supported
@@ -412,7 +426,7 @@ const operators = {
       else
         return `${field} ${opStr} ${values}`;
     },
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value")
       // set
         return `${field} = '${values.map(v => SqlString.trim(v)).join(",")}'`;
@@ -439,7 +453,7 @@ const operators = {
       else
         return `${field} != ${values}`;
     },
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       if (valueSrc == "value")
       // set
         return `${field} != '${values.map(v => SqlString.trim(v)).join(",")}'`;
@@ -466,7 +480,7 @@ const operators = {
       const prox = operatorOptions.get("proximity");
       return `${field} ${val1} NEAR/${prox} ${val2}`;
     },
-    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+    sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
       const val1 = values.first();
       const val2 = values.get(1);
       const aVal1 = SqlString.trim(val1);

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -295,14 +295,13 @@ const operators = {
       return isForDisplay ? `${field} IS EMPTY` : `${field} IS EMPTY`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      if (valueSrc == "value") {
-        if (fieldDef.type == 'text') {
-          return `${field} = ''`;
-        }
+      if (fieldDef.type == 'text') {
+        // todo: ISNULL
+        return `${field} = ''`;
       }
       return undefined; // not supported
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false), // todo! change
     jsonLogic: "!",
   },
   is_not_empty: {
@@ -315,14 +314,13 @@ const operators = {
       return isForDisplay ? `${field} IS NOT EMPTY` : `${field} IS NOT EMPTY`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      if (valueSrc == "value") {
-        if (fieldDef.type == 'text') {
-          return `${field} <> ''`;
-        }
+      if (fieldDef.type == 'text') {
+        // todo: ISNULL
+        return `${field} <> ''`;
       }
       return undefined; // not supported
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false), // todo! change
     jsonLogic: "!!",
     elasticSearchQueryType: "exists",
   },
@@ -336,7 +334,7 @@ const operators = {
       return isForDisplay ? `${field} IS NULL` : `!${field}`;
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
-    jsonLogic: "!"
+    jsonLogic: "!" // todo! change, compare with null
   },
   is_not_null: {
     label: "Is not null",
@@ -348,7 +346,7 @@ const operators = {
       return isForDisplay ? `${field} IS NOT NULL` : `!!${field}`;
     },
     mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
-    jsonLogic: "!!",
+    jsonLogic: "!!", // todo! change, compare with null
     elasticSearchQueryType: "exists",
   },
   select_equals: {

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -294,16 +294,12 @@ const operators = {
     cardinality: 0,
     reversedOp: "is_not_empty",
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
-      return isForDisplay ? `${field} IS EMPTY` : `${field} IS EMPTY`;
+      return isForDisplay ? `${field} IS EMPTY` : `!${field}`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      if (fieldDef.type == 'text') {
-        // todo: ISNULL
-        return `${field} = ''`;
-      }
-      return undefined; // not supported
+      return `${field} = ${sqlEmptyValue(fieldDef)}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false), // todo! change
+    mongoFormatOp: mongoFormatOp1.bind(null, "$eq", (v, fieldDef) => mongoEmptyValue(fieldDef), false),
     jsonLogic: "!",
   },
   is_not_empty: {
@@ -313,16 +309,12 @@ const operators = {
     cardinality: 0,
     reversedOp: "is_empty",
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
-      return isForDisplay ? `${field} IS NOT EMPTY` : `${field} IS NOT EMPTY`;
+      return isForDisplay ? `${field} IS NOT EMPTY` : `!!${field}`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      if (fieldDef.type == 'text') {
-        // todo: ISNULL
-        return `${field} <> ''`;
-      }
-      return undefined; // not supported
+      return `${field} <> ${sqlEmptyValue(fieldDef)}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false), // todo! change
+    mongoFormatOp: mongoFormatOp1.bind(null, "$ne", (v, fieldDef) => mongoEmptyValue(fieldDef), false),
     jsonLogic: "!!",
     elasticSearchQueryType: "exists",
   },
@@ -335,8 +327,9 @@ const operators = {
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
       return isForDisplay ? `${field} IS NULL` : `!${field}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
-    jsonLogic: "!" // todo! change, compare with null
+    //mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$eq", v => null, false),
+    jsonLogic: "==",
   },
   is_not_null: {
     label: "Is not null",
@@ -347,8 +340,9 @@ const operators = {
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
       return isForDisplay ? `${field} IS NOT NULL` : `!!${field}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
-    jsonLogic: "!!", // todo! change, compare with null
+    //mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$ne", v => null, false),
+    jsonLogic: "!=",
     elasticSearchQueryType: "exists",
   },
   select_equals: {
@@ -867,8 +861,8 @@ const types = {
           "greater_or_equal",
           "between",
           "not_between",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ],
@@ -881,8 +875,8 @@ const types = {
           "less_or_equal",
           "greater",
           "greater_or_equal",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null"
         ],
@@ -902,8 +896,8 @@ const types = {
           "greater_or_equal",
           "between",
           "not_between",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null"
         ]
@@ -923,8 +917,8 @@ const types = {
           "greater_or_equal",
           "between",
           "not_between",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ]
@@ -944,8 +938,8 @@ const types = {
           "greater_or_equal",
           "between",
           "not_between",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ],
@@ -960,8 +954,8 @@ const types = {
         operators: [
           "select_equals",
           "select_not_equals",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ],
@@ -975,8 +969,8 @@ const types = {
         operators: [
           "select_any_in",
           "select_not_any_in",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ],
@@ -990,8 +984,8 @@ const types = {
         operators: [
           "multiselect_equals",
           "multiselect_not_equals",
-          "is_empty",
-          "is_not_empty",
+          // "is_empty",
+          // "is_not_empty",
           "is_null",
           "is_not_null",
         ]

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -297,9 +297,10 @@ const operators = {
       return isForDisplay ? `${field} IS EMPTY` : `!${field}`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      return `${field} = ${sqlEmptyValue(fieldDef)}`;
+      const empty = sqlEmptyValue(fieldDef);
+      return `COALESCE(${field}, ${empty}) = ${empty}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$eq", (v, fieldDef) => mongoEmptyValue(fieldDef), false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$in", (v, fieldDef) => [mongoEmptyValue(fieldDef), null], false),
     jsonLogic: "!",
   },
   is_not_empty: {
@@ -312,9 +313,10 @@ const operators = {
       return isForDisplay ? `${field} IS NOT EMPTY` : `!!${field}`;
     },
     sqlFormatOp: (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
-      return `${field} <> ${sqlEmptyValue(fieldDef)}`;
+      const empty = sqlEmptyValue(fieldDef);
+      return `COALESCE(${field}, ${empty}) <> ${empty}`;
     },
-    mongoFormatOp: mongoFormatOp1.bind(null, "$ne", (v, fieldDef) => mongoEmptyValue(fieldDef), false),
+    mongoFormatOp: mongoFormatOp1.bind(null, "$nin", (v, fieldDef) => [mongoEmptyValue(fieldDef), null], false),
     jsonLogic: "!!",
     elasticSearchQueryType: "exists",
   },
@@ -327,7 +329,7 @@ const operators = {
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
       return isForDisplay ? `${field} IS NULL` : `!${field}`;
     },
-    //mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => false, false),
+    // check if value is null OR not exists
     mongoFormatOp: mongoFormatOp1.bind(null, "$eq", v => null, false),
     jsonLogic: "==",
   },
@@ -340,7 +342,7 @@ const operators = {
     formatOp: (field, op, value, valueSrc, valueType, opDef, operatorOptions, isForDisplay) => {
       return isForDisplay ? `${field} IS NOT NULL` : `!!${field}`;
     },
-    //mongoFormatOp: mongoFormatOp1.bind(null, "$exists", v => true, false),
+    // check if value exists and is not null
     mongoFormatOp: mongoFormatOp1.bind(null, "$ne", v => null, false),
     jsonLogic: "!=",
     elasticSearchQueryType: "exists",

--- a/modules/config/material/index.js
+++ b/modules/config/material/index.js
@@ -1,7 +1,7 @@
 import MaterialWidgets from "../../components/widgets/material";
 import BasicConfig, {stringifyForDisplay} from "../basic";
 import React from "react";
-import {SqlString} from "../../utils/sql";
+import {SqlString} from "../../utils/export";
 
 
 const {

--- a/modules/export/mongoDb.js
+++ b/modules/export/mongoDb.js
@@ -227,6 +227,7 @@ const formatRule = (parents, item, config, meta, _not = false, _canWrapExpr = tr
     (valueTypes.length > 1 ? valueTypes : valueTypes[0]),
     omit(operatorDefinition, ["formatOp", "mongoFormatOp", "sqlFormatOp", "jsonLogic"]),
     operatorOptions,
+    fieldDef,
   ];
   let ruleQuery = fn(...args);
   if (wrapExpr) {

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -163,7 +163,7 @@ const formatRule = (item, config, meta) => {
     ret = config.settings.sqlFormatReverse(ret, operator, reversedOp, operatorDefinition, revOperatorDefinition);
   }
   if (ret === undefined) {
-    meta.errors.push(`Operator ${operator} is not supported for value source ${valueSrcs.join(', ')}`);
+    meta.errors.push(`Operator ${operator} is not supported for value source ${valueSrcs.join(", ")}`);
     return undefined;
   }
   return ret;

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -122,16 +122,16 @@ const formatRule = (item, config, meta) => {
   if (!fn) {
     const sqlOp = operatorDefinition.sqlOp || operator;
     if (cardinality == 0) {
-      fn = (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+      fn = (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
         return `${field} ${sqlOp}`;
       };
     } else if (cardinality == 1) {
-      fn = (field, op, value, valueSrc, valueType, opDef, operatorOptions) => {
+      fn = (field, op, value, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
         return `${field} ${sqlOp} ${value}`;
       };
     } else if (cardinality == 2) {
       // between
-      fn = (field, op, values, valueSrc, valueType, opDef, operatorOptions) => {
+      fn = (field, op, values, valueSrc, valueType, opDef, operatorOptions, fieldDef) => {
         const valFrom = values.first();
         const valTo = values.get(1);
         return `${field} ${sqlOp} ${valFrom} AND ${valTo}`;
@@ -155,6 +155,7 @@ const formatRule = (item, config, meta) => {
     (valueTypes.length > 1 ? valueTypes : valueTypes[0]),
     omit(operatorDefinition, ["formatOp", "mongoFormatOp", "sqlFormatOp", "jsonLogic"]),
     operatorOptions,
+    fieldDefinition,
   ];
 
   let ret;

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -11,7 +11,7 @@ import {defaultConjunction} from "../utils/defaultUtils";
 import {settings as defaultSettings} from "../config/default";
 import {completeValue} from "../utils/funcUtils";
 import {Map} from "immutable";
-import {SqlString} from "../utils/sql";
+import {SqlString} from "../utils/export";
 
 
 export const sqlFormat = (tree, config) => {

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -157,9 +157,14 @@ const formatRule = (item, config, meta) => {
     operatorOptions,
   ];
 
-  let ret = fn(...args);
+  let ret;
+  ret = fn(...args);
   if (isRev) {
     ret = config.settings.sqlFormatReverse(ret, operator, reversedOp, operatorDefinition, revOperatorDefinition);
+  }
+  if (ret === undefined) {
+    meta.errors.push(`Operator ${operator} is not supported for value source ${valueSrcs.join(', ')}`);
+    return undefined;
   }
   return ret;
 };

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -450,7 +450,12 @@ const _parseRule = (op, arity, vals, parentField, conv, config, errors, isRevArg
   // but don't confuse with "all-in" for multiselect
   const isAllInForMultiselect = op == "all" && isJsonLogic(vals[1]) && Object.keys(vals[1])[0] == "in";
   const isGroup0 = !isAllInForMultiselect && config.settings.groupOperators.includes(op);
-  const cardinality = isGroup0 ? 0 : arity - 1;
+  const eqOps = ["==", "!="];
+  let cardinality = isGroup0 ? 0 : arity - 1;
+  if (isGroup0)
+    cardinality = 0;
+  else if (eqOps.includes(op) && cardinality == 1 && vals[1] === null)
+    cardinality = 0;
 
   const opk = op + "/" + cardinality;
   const {fieldSeparator} = config.settings;

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -418,7 +418,7 @@ export interface RuleErrorProps {
 
 type FormatOperator = (field: string, op: string, vals: string | Array<string>, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject, isForDisplay?: boolean) => string;
 type MongoFormatOperator = (field: string, op: string, vals: MongoValue | Array<MongoValue>, useExpr?: boolean, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject) => Object;
-type SqlFormatOperator = (field: string, op: string, vals: string | Array<string>, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject) => string;
+type SqlFormatOperator = (field: string, op: string, vals: string | Array<string>, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject, fieldDef?: Field) => string;
 type JsonLogicFormatOperator = (field: JsonLogicField, op: string, vals: JsonLogicValue | Array<JsonLogicValue>, opDef?: Operator, operatorOptions?: AnyObject) => JsonLogicTree;
 type ElasticSearchFormatQueryType = (valueType: string) => ElasticSearchQueryType;
 

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -417,9 +417,9 @@ export interface RuleErrorProps {
 /////////////////
 
 type FormatOperator = (field: string, op: string, vals: string | Array<string>, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject, isForDisplay?: boolean) => string;
-type MongoFormatOperator = (field: string, op: string, vals: MongoValue | Array<MongoValue>, useExpr?: boolean, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject) => Object;
+type MongoFormatOperator = (field: string, op: string, vals: MongoValue | Array<MongoValue>, useExpr?: boolean, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject, fieldDef?: Field) => Object;
 type SqlFormatOperator = (field: string, op: string, vals: string | Array<string>, valueSrc?: ValueSource, valueType?: string, opDef?: Operator, operatorOptions?: AnyObject, fieldDef?: Field) => string;
-type JsonLogicFormatOperator = (field: JsonLogicField, op: string, vals: JsonLogicValue | Array<JsonLogicValue>, opDef?: Operator, operatorOptions?: AnyObject) => JsonLogicTree;
+type JsonLogicFormatOperator = (field: JsonLogicField, op: string, vals: JsonLogicValue | Array<JsonLogicValue>, opDef?: Operator, operatorOptions?: AnyObject, fieldDef?: Field) => JsonLogicTree;
 type ElasticSearchFormatQueryType = (valueType: string) => ElasticSearchQueryType;
 
 interface ProximityConfig {

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -2,7 +2,7 @@ import merge from "lodash/merge";
 import mergeWith from "lodash/mergeWith";
 import {settings as defaultSettings} from "../config/default";
 import moment from "moment";
-import {normalizeListValues} from "./stuff";
+import {normalizeListValues, mergeArraysSmart} from "./stuff";
 import {getWidgetForFieldOp} from "./ruleUtils";
 import clone from "clone";
 
@@ -53,10 +53,7 @@ function _extendTypeConfig(type, typeConfig, config) {
   for (let widget in typeConfig.widgets) {
     let typeWidgetConfig = typeConfig.widgets[widget];
     if (typeWidgetConfig.operators) {
-      if (!operators)
-        operators = [];
-            
-      operators = operators.concat(typeWidgetConfig.operators.slice());
+      operators = mergeArraysSmart(operators, typeWidgetConfig.operators);
     }
     if (typeWidgetConfig.defaultOperator)
       defaultOperator = typeWidgetConfig.defaultOperator;

--- a/modules/utils/export.js
+++ b/modules/utils/export.js
@@ -21,4 +21,28 @@ SqlString.escapeLike = (val, any_start = true, any_end = true) => {
   return res;
 };
 
-export {SqlString};
+const sqlEmptyValue = (fieldDef) => {
+  let v = '';
+  const type = fieldDef?.type;
+  if (type == "date") {
+    v = `'1970-01-01'`;
+  } else if (type == "datetime") {
+    v = `'1970-01-01 00:00'`;
+  } else if (type == "time") {
+    v = `'00:00'`;
+  } else if (type == "number") {
+    v = `0`;
+  }
+  return v;
+};
+
+const mongoEmptyValue = (fieldDef) => {
+  let v = '';
+  const type = fieldDef?.type;
+  if (type == "number") {
+    v = 0;
+  }
+  return v;
+};
+
+export {SqlString, sqlEmptyValue, mongoEmptyValue};

--- a/modules/utils/export.js
+++ b/modules/utils/export.js
@@ -22,7 +22,7 @@ SqlString.escapeLike = (val, any_start = true, any_end = true) => {
 };
 
 const sqlEmptyValue = (fieldDef) => {
-  let v = '';
+  let v = `''`;
   const type = fieldDef?.type;
   if (type == "date") {
     v = `'1970-01-01'`;

--- a/modules/utils/export.js
+++ b/modules/utils/export.js
@@ -22,23 +22,23 @@ SqlString.escapeLike = (val, any_start = true, any_end = true) => {
 };
 
 const sqlEmptyValue = (fieldDef) => {
-  let v = `''`;
+  let v = "''";
   const type = fieldDef?.type;
   if (type == "date") {
     //todo: support other SQL dialects?  0001-01-01 for oracle, 1970-01-01 for timestamp
-    v = `'0000-00-00'`;
+    v = "'0000-00-00'";
   } else if (type == "datetime") {
-    v = `'0000-00-00 00:00'`;
+    v = "'0000-00-00 00:00'";
   } else if (type == "time") {
-    v = `'00:00'`;
+    v = "'00:00'";
   } else if (type == "number") {
-    v = `0`;
+    v = "0";
   }
   return v;
 };
 
 const mongoEmptyValue = (fieldDef) => {
-  let v = '';
+  let v = "";
   const type = fieldDef?.type;
   if (type == "number") {
     v = 0;

--- a/modules/utils/export.js
+++ b/modules/utils/export.js
@@ -25,9 +25,10 @@ const sqlEmptyValue = (fieldDef) => {
   let v = `''`;
   const type = fieldDef?.type;
   if (type == "date") {
-    v = `'1970-01-01'`;
+    //todo: support other SQL dialects?  0001-01-01 for oracle, 1970-01-01 for timestamp
+    v = `'0000-00-00'`;
   } else if (type == "datetime") {
-    v = `'1970-01-01 00:00'`;
+    v = `'0000-00-00 00:00'`;
   } else if (type == "time") {
     v = `'00:00'`;
   } else if (type == "number") {

--- a/modules/utils/stuff.js
+++ b/modules/utils/stuff.js
@@ -310,36 +310,36 @@ export function mergeArraysSmart(arr1, arr2) {
   if (!arr1) arr1 = [];
   if (!arr2) arr2 = [];
   return arr2
-  .map(op => [op, arr1.indexOf(op)])
-  .map(([op, ind], i, orig) => {
-    if (ind == -1) {
-      const next = orig.slice(i+1);
-      const prev = orig.slice(0, i);
-      const after = prev.reverse().find(([_cop, ci]) => ci != -1);
-      const before = next.find(([_cop, ci]) => ci != -1);
-      if (before)
-        return [op, 'before', before[0]];
-      else if (after)
-        return [op, 'after', after[0]];
-      else
-        return [op, 'append', null];
-    } else {
-      // already exists
-      return null;
-    }
-  })
-  .filter(x => x !== null)
-  .reduce((acc, [newOp, rel, relOp]) => {
-    const ind = acc.indexOf(relOp);
-    if (acc.indexOf(newOp) == -1) {
-      if (ind > -1) {
-        // insert after or before
-        acc.splice( ind + (rel == 'after' ? 1 : 0), 0, newOp );
+    .map(op => [op, arr1.indexOf(op)])
+    .map(([op, ind], i, orig) => {
+      if (ind == -1) {
+        const next = orig.slice(i+1);
+        const prev = orig.slice(0, i);
+        const after = prev.reverse().find(([_cop, ci]) => ci != -1);
+        const before = next.find(([_cop, ci]) => ci != -1);
+        if (before)
+          return [op, "before", before[0]];
+        else if (after)
+          return [op, "after", after[0]];
+        else
+          return [op, "append", null];
       } else {
-        // insert to end or start
-        acc.splice( (rel == 'append' ? Infinity : 0), 0, newOp );
+      // already exists
+        return null;
       }
-    }
-    return acc;
-  }, arr1.slice());
-};
+    })
+    .filter(x => x !== null)
+    .reduce((acc, [newOp, rel, relOp]) => {
+      const ind = acc.indexOf(relOp);
+      if (acc.indexOf(newOp) == -1) {
+        if (ind > -1) {
+        // insert after or before
+          acc.splice( ind + (rel == "after" ? 1 : 0), 0, newOp );
+        } else {
+        // insert to end or start
+          acc.splice( (rel == "append" ? Infinity : 0), 0, newOp );
+        }
+      }
+      return acc;
+    }, arr1.slice());
+}

--- a/tests/specs/QueryWithGroupsAndStructs.test.js
+++ b/tests/specs/QueryWithGroupsAndStructs.test.js
@@ -41,7 +41,7 @@ describe("query with !struct and !group", () => {
     export_checks(configs.with_struct_and_group, inits.with_struct_and_group, "JsonLogic", {
       "query": "((results.slider == 22 && results.stock == true) && user.firstName == \"abc\" && !!user.login)",
       "queryHuman": "((Results.Slider = 22 AND Results.In stock) AND Username = abc AND User.login IS NOT EMPTY)",
-      "sql": "((results.slider = 22 AND results.stock = true) AND user.firstName = 'abc' AND user.login <> '')",
+      "sql": "((results.slider = 22 AND results.stock = true) AND user.firstName = 'abc' AND COALESCE(user.login, '') <> '')",
       "mongo": {
         "results": {
           "$elemMatch": {
@@ -51,7 +51,7 @@ describe("query with !struct and !group", () => {
         },
         "user.firstName": "abc",
         "user.login": {
-          "$ne": ""
+          "$nin": ["", null]
         }
       },
       "logic": {

--- a/tests/specs/QueryWithGroupsAndStructs.test.js
+++ b/tests/specs/QueryWithGroupsAndStructs.test.js
@@ -41,7 +41,7 @@ describe("query with !struct and !group", () => {
     export_checks(configs.with_struct_and_group, inits.with_struct_and_group, "JsonLogic", {
       "query": "((results.slider == 22 && results.stock == true) && user.firstName == \"abc\" && !!user.login)",
       "queryHuman": "((Results.Slider = 22 AND Results.In stock) AND Username = abc AND User.login IS NOT EMPTY)",
-      "sql": "((results.slider = 22 AND results.stock = true) AND user.firstName = 'abc' AND user.login IS NOT EMPTY)",
+      "sql": "((results.slider = 22 AND results.stock = true) AND user.firstName = 'abc' AND user.login <> '')",
       "mongo": {
         "results": {
           "$elemMatch": {
@@ -51,7 +51,7 @@ describe("query with !struct and !group", () => {
         },
         "user.firstName": "abc",
         "user.login": {
-          "$exists": true
+          "$ne": ""
         }
       },
       "logic": {
@@ -119,7 +119,7 @@ describe("query with !group", () => {
     export_checks(configs.with_group_struct, inits.with_is_empty_in_some, "JsonLogic", {
       "logic": {
         "and": [{
-          "!": { "var": "results.score" }
+          "!": { "var": "results.grade" }
         } ]
       }
     });

--- a/tests/specs/QueryWithOperators.test.js
+++ b/tests/specs/QueryWithOperators.test.js
@@ -7,8 +7,8 @@ describe("query with ops", () => {
   describe("export", () => {
     export_checks(configs.with_all_types, inits.with_ops, "JsonLogic", {
       "query": "(num != 2 && str Like \"abc\" && str Not Like \"xyz\" && num >= 1 && num <= 2 && !(num >= 3 && num <= 4) && !num && color IN (\"yellow\") && color NOT IN (\"green\") && multicolor != [\"yellow\"])",
-      "queryHuman": "(Number != 2 AND String Like abc AND String Not Like xyz AND Number BETWEEN 1 AND 2 AND NOT (Number BETWEEN 3 AND 4) AND Number IS EMPTY AND Color IN (Yellow) AND Color NOT IN (Green) AND Colors != [Yellow])",
-      "sql": "(num <> 2 AND str LIKE '%abc%' AND str NOT LIKE '%xyz%' AND num BETWEEN 1 AND 2 AND num NOT BETWEEN 3 AND 4 AND num IS EMPTY AND color IN ('yellow') AND color NOT IN ('green') AND multicolor != 'yellow')",
+      "queryHuman": "(Number != 2 AND String Like abc AND String Not Like xyz AND Number BETWEEN 1 AND 2 AND NOT (Number BETWEEN 3 AND 4) AND Number IS NULL AND Color IN (Yellow) AND Color NOT IN (Green) AND Colors != [Yellow])",
+      "sql": "(num <> 2 AND str LIKE '%abc%' AND str NOT LIKE '%xyz%' AND num BETWEEN 1 AND 2 AND num NOT BETWEEN 3 AND 4 AND num IS NULL AND color IN ('yellow') AND color NOT IN ('green') AND multicolor != 'yellow')",
       "mongo": {
         "num": {
           "$ne": 2,
@@ -18,7 +18,7 @@ describe("query with ops", () => {
             "$gte": 3,
             "$lte": 4
           },
-          "$exists": false
+          "$eq": null
         },
         "str": {
           "$regex": "abc",
@@ -52,7 +52,7 @@ describe("query with ops", () => {
           }, {
             "!": {  "<=": [ 3,  { "var": "num" },  4 ]  }
           }, {
-            "!": { "var": "num" }
+            "==": [ { "var": "num" }, null ]
           }, {
             "in": [
               { "var": "color" },  [ "yellow" ]

--- a/tests/support/configs.js
+++ b/tests/support/configs.js
@@ -257,8 +257,8 @@ export const with_group_struct = (BasicConfig) => ({
       type: "!group",
       mode: "struct",
       subfields: {
-        score: {
-          type: "number",
+        grade: {
+          type: "text",
         }
       }
     },
@@ -276,8 +276,8 @@ export const with_group_some = (BasicConfig) => ({
       type: "!group",
       mode: "some",
       subfields: {
-        score: {
-          type: "number",
+        grade: {
+          type: "text",
         }
       }
     },
@@ -295,8 +295,8 @@ export const with_group_array = (BasicConfig) => ({
       type: "!group",
       mode: "array",
       subfields: {
-        score: {
-          type: "number",
+        grade: {
+          type: "text",
         }
       }
     },

--- a/tests/support/inits.js
+++ b/tests/support/inits.js
@@ -148,7 +148,7 @@ export const with_is_empty_in_some = {
     { "some": [
       { "var": "results" },
       {
-        "!": { "var": "score" }
+        "!": { "var": "grade" }
       }
     ] }
   ]
@@ -181,7 +181,7 @@ export const with_not_and_in_some = {
     { "some": [
       { "var": "cars" },
       { "!": { "and": [
-        { "!": { "var": "year" } },
+        { "==": [ { "var": "year" }, null ] },
         { "!": { "in": [ { "var": "vendor" }, [ "Ford", "Toyota" ] ] } }
       ] } }
     ] }


### PR DESCRIPTION
Resolves #494

**! Breaking change** for operators `is_empty` and `is_not_empty`. 
Now these operstors can be used for text type only (for other types they will be auto converted to `is_null`/`is_not_null` during loading of query value created with previous versions). 
Changed meaning of `is_empty` - now it's just strict comparing with empty string. 
Before change the meaning was similar to `is_null`. 
If you used `is_empty` for text types with intention of comparing with null, please replace `is_empty` -> `is_null`, `is_not_empty` -> `is_not_null` in saved query values. 
If you used JsonLogic for saving, you need to replace `{"!": {"var": "your_field"}}` -> `{"==": [{"var": "your_field"}, null]}` and `{"!!": {"var": "your_field"}}` -> `{"!=": [{"var": "your_field"}, null]}`.