### PR TITLE
Add instructions for using QB inside Fluent UI Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Props:
 - If you put query builder component inside [Material-UI](https://github.com/mui-org/material-ui)'s `<Dialog />` or `<Popover />`, please:
   - use prop `disableEnforceFocus={true}` for dialog or popver
   - set css `.MuiPopover-root, .MuiDialog-root { z-index: 900 !important; }` (or 1000 for AntDesign v3)
+- If you put query builder component inside [Fluent-UI](https://developer.microsoft.com/en-us/fluentui)'s `<Panel />`, please:
+  - set css `.ms-Layer.ms-Layer--fixed.root-119 { z-index: 900 !important; }`
 - `props` arg in `renderBuilder` have `actions` and `dispatch` you can use to run actions programmatically (for list of actions see `Actions` in [`index.d.ts`](/modules/index.d.ts)).
 
 ### `<Builder />`


### PR DESCRIPTION
When placing the query builder inside a Fluent UI <Panel/> component, field selectors don't show any options when clicked (except with BasicConfig). I managed to fix this by adding a CSS statement similar to the one mentioned for Material UI's <Dialog /> but tailored for FluentUI's specific class.