### PR TITLE
hide divider when has no load more

### DIFF
--- a/modules/components/widgets/antd/value/Autocomplete.jsx
+++ b/modules/components/widgets/antd/value/Autocomplete.jsx
@@ -99,10 +99,14 @@ export default (props) => {
   const dropdownRender = (menu) => (
     <div>
       {menu}
-      <Divider />
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        {specialOptions}
-      </div>
+      {specialOptions.length > 0
+        && <>
+          <Divider style={{ margin: "0px" }}/>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {specialOptions}
+          </div>
+        </>
+      }
     </div>
   );
 


### PR DESCRIPTION
I set divider margin to 0 to avoid this:
![Big divider due to antd-css](https://user-images.githubusercontent.com/7309715/153649399-90afbd60-9070-495c-a319-4e3da07578b6.gif)

