### PR TITLE
only set value when different

### DIFF
--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -254,7 +254,9 @@ const validateValueInList = (value, listValues) => {
       if (vv == undefined) {
         return [`Value ${value[i]} is not in list of values`, value];
       } else {
-        value[i] = vv.value;
+        if (value[i] !== vv.value) {
+          value[i] = vv.value;
+        }
       }
     }
   } else {


### PR DESCRIPTION
i have a use case for RAQB where i need to update selection values based on other selection values.  for reasons i don't fully understand this SOMETIMES throws the error below.

i have double-triple-checked that i am not passing anything frozen/immutable/read-only into the RAQB so i am pretty sure the read-only logic is occurring inside the RAQB code.  i dug in and found that the error is thrown at:

```
value[i] = vv.value;
```

but the error only occurs when `value[i]` already equals `vv.value`.  thus the patch:

```
if (value[i] !== vv.value) {
  value[i] = vv.value;
}
```

i don't claim to fully understand what is going on in the larger context, but i figured i would bounce what i found back to you all.  also, the diff feels relatively innocuous.

my use case is a component that i have built that is used in a number of other projects and extracting out a minimal use case would be a significant effort, otherwise, i would provide that.  if it turns out that some random patch from some random dude isn't enough justification to accept it, i can just run my code on my own fork.  :)

### error thrown:

```
TypeError: Cannot assign to read only property '0' of object '[object Array]'
    at validateValueInList (validation.js:310:1)
    at validateNormalValue (validation.js:354:1)
    at validateValue (validation.js:261:1)
    at _loop (ruleUtils.js:106:1)
    at getNewValueForFieldOp (ruleUtils.js:127:1)
    at validateRule (validation.js:197:1)
    at validateItem (validation.js:56:1)
    at validation.js:77:1
    at immutable.js:3016:1
    at immutable.js:2699:1
    at List.__iterate (immutable.js:2206:1)
    at OrderedMap.__iterate (immutable.js:2698:1)
    at KeyedIterable.mappedSequence.__iterateUncached (immutable.js:3015:1)
    at seqIterate (immutable.js:604:1)
    at KeyedIterable.Seq.__iterate (immutable.js:274:1)
    at KeyedIterable.forEach (immutable.js:4381:1)
    at immutable.js:2651:1
    at OrderedMap.Map.withMutations (immutable.js:1353:1)
    at OrderedMap [as constructor] (immutable.js:2646:1)
    at reify (immutable.js:3570:1)
    at OrderedMap.map (immutable.js:4401:1)
    at validateGroup (validation.js:76:1)
    at validateItem (validation.js:54:1)
    at validateTree (validation.js:44:1)
    at validateAndFixTree (Query.js:53:1)
    at Query.validateTree (Query.js:82:1)
    at Query.onPropsChanged (Query.js:104:1)
    at Query.obj.UNSAFE_componentWillReceiveProps (reactUtils.js:63:1)
    at callComponentWillReceiveProps (react-dom.development.js:12808:1)
    at updateClassInstance (react-dom.development.js:13006:1)
    at updateClassComponent (react-dom.development.js:17432:1)
    at beginWork (react-dom.development.js:19073:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:3945:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:1)
    at invokeGuardedCallback (react-dom.development.js:4056:1)
    at beginWork$1 (react-dom.development.js:23964:1)
    at performUnitOfWork (react-dom.development.js:22776:1)
    at workLoopSync (react-dom.development.js:22707:1)
    at renderRootSync (react-dom.development.js:22670:1)
    at performSyncWorkOnRoot (react-dom.development.js:22293:1)
    at react-dom.development.js:11327:1
    at unstable_runWithPriority (scheduler.development.js:468:1)
    at runWithPriority$1 (react-dom.development.js:11276:1)
    at flushSyncCallbackQueueImpl (react-dom.development.js:11322:1)
    at flushSyncCallbackQueue (react-dom.development.js:11309:1)
    at scheduleUpdateOnFiber (react-dom.development.js:21893:1)
    at dispatchAction (react-dom.development.js:16139:1)
    at _callee$ (index.jsx:123:1)
    at tryCatch (runtime.js:63:1)
```