### PR TITLE
Breaking change: children1 is now array in result of getTree() to preserve items order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+- 5.2.0
+  - ! Breaking change: `children1` is now array in result of `getTree()` to preserve items order (PR #672) (issues #589, #670)
+    `Utils.getTree(tree, true, false)` will behave same as before this change.
 - 5.1.2
   - Added config `removeIncompleteRulesOnLoad` (default false) (PR #661) (issue #642)
   - Fix error when using same field for comparison as argument of function (PR #662) (issue #612)

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Wrapping in `div.query-builder-container` is necessary if you put query builder 
 
 ### `Utils`
 - Save, load:
-  #### getTree (immutableValue, light = true) -> Object
+  #### getTree (immutableValue, light = true, children1AsArray = true) -> Object
   Convert query value from internal Immutable format to JS format. 
   You can use it to save value on backend in `onChange` callback of `<Query>`.  
   Tip: Use `light = false` in case if you want to store query value in your state in JS format and pass it as `value` of `<Query>` after applying `loadTree()` (which is not recommended because of double conversion). See issue [#190](https://github.com/ukrbublik/react-awesome-query-builder/issues/190)

--- a/modules/import/tree.js
+++ b/modules/import/tree.js
@@ -4,12 +4,12 @@ import {extendConfig} from "../utils/configUtils";
 import {getTreeBadFields, getLightTree} from "../utils/treeUtils";
 import {isJsonLogic} from "../utils/stuff";
 
-export const getTree = (immutableTree, light = true) => {
+export const getTree = (immutableTree, light = true, children1AsArray = true) => {
   if (!immutableTree) return undefined;
   let tree = immutableTree;
   tree = tree.toJS();
   if (light)
-    tree = getLightTree(tree);
+    tree = getLightTree(tree, children1AsArray);
   return tree;
 };
 
@@ -72,6 +72,8 @@ function jsTreeToImmutable(tree) {
     } else if (key == "asyncListValues") {
       // keep in JS format
       outValue = value.toJS();
+    } else if (key == "children1" && Immutable.Iterable.isIndexed(value)) {
+      outValue = new Immutable.OrderedMap(value.map(child => [child.get("id"), child]));
     } else {
       outValue = Immutable.Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap();
     }

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -170,7 +170,7 @@ export interface Utils {
   _mongodbFormat(tree: ImmutableTree, config: Config): [Object | undefined, Array<string>];
   elasticSearchFormat(tree: ImmutableTree, config: Config): Object | undefined;
   // load, save
-  getTree(tree: ImmutableTree, light?: boolean): JsonTree;
+  getTree(tree: ImmutableTree, light?: boolean, children1AsArray?: boolean): JsonTree;
   loadTree(jsonTree: JsonTree): ImmutableTree;
   checkTree(tree: ImmutableTree, config: Config): ImmutableTree;
   isValidTree(tree: ImmutableTree): boolean;

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -361,13 +361,13 @@ export const getTreeBadFields = (tree) => {
 
 // Remove fields that can be calced: "id", "path"
 // Remove empty fields: "operatorOptions"
-export const getLightTree = (tree) => {
+export const getLightTree = (tree, children1AsArray = false) => {
   let newTree = tree;
 
   function _processNode (item, itemId) {
     if (item.path)
       delete item.path;
-    if (itemId)
+    if (!children1AsArray && itemId)
       delete item.id;
     let properties = item.properties;
     if (properties) {
@@ -379,6 +379,9 @@ export const getLightTree = (tree) => {
     if (children) {
       for (let id in children) {
         _processNode(children[id], id);
+      }
+      if (children1AsArray) {
+        item.children1 = Object.values(children);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",


### PR DESCRIPTION
Resolves https://github.com/ukrbublik/react-awesome-query-builder/issues/589 and https://github.com/ukrbublik/react-awesome-query-builder/discussions/670

**Issue:** 
In result of `Utils.getTree()` order of items in `children1` is not guaranteed because it's associative array.
Order CAN be preserved after `JSON.stringify` -> `JSON.parse` but it's not reliable.
Order is NOT preserved after saving and loading from MongoDb.

**Breaking change:** 
`children1` is now indexed array instead of object

Before:
```js
children1: {
  '<id1>': { type: 'rule', properties: ... },
  '<id2>': { type: 'rule', properties: ... }
}
```
After:
```js
children1: [
  { id: '<id1>', type: 'rule', properties: ... },
  { id: '<id2>', type: 'rule', properties: ... },
]
```
**Compatibility:** 
- `Utils.loadTree()` is backward comatible with `children1` being array or object.
- `Utils.getTree(tree, true, false)` will behave same as before this change