### PR TITLE
Allow self nesting of functions

### DIFF
--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -724,4 +724,5 @@ To enable this feature set `valueSources` of type to `['value', 'func']` (see be
 |args.<arg>.isOptional | |false |Last args can be optional
 |renderBrackets | |`['(', ')']` |Can render custom function brackets in UI (or not render).
 |renderSeps | |`[', ']` |Can render custom arguments separators in UI (other than `,`).
+|allowSelfNesting | |false |Allows the function to be used within its own parameters.
 |===

--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -724,5 +724,5 @@ To enable this feature set `valueSources` of type to `['value', 'func']` (see be
 |args.<arg>.isOptional | |false |Last args can be optional
 |renderBrackets | |`['(', ')']` |Can render custom function brackets in UI (or not render).
 |renderSeps | |`[', ']` |Can render custom arguments separators in UI (other than `,`).
-|allowSelfNesting | |false |Allows the function to be used within its own parameters.
+|allowSelfNesting | |false |Allows the function to be used within its own arguments.
 |===

--- a/modules/components/rule/FuncSelect.jsx
+++ b/modules/components/rule/FuncSelect.jsx
@@ -113,7 +113,7 @@ export default class FuncSelect extends PureComponent {
           if (canUseFuncForField)
             canUse = canUse && canUseFuncForField(leftFieldFullkey, leftFieldConfig, funcFullkey, funcConfig, operator);
           // don't use func in func (can be configurable, but usually users don't need this)
-          if (parentFuncs && parentFuncs.includes(funcFullkey))
+          if (!funcConfig.allowSelfNesting && parentFuncs && parentFuncs.includes(funcFullkey))
             canUse = false;
           if (!canUse)
             delete list[funcKey];

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -912,6 +912,7 @@ export interface Func {
   renderBrackets?: Array<ReactElement | string>,
   renderSeps?: Array<ReactElement | string>,
   spelFormatFunc?: SpelFormatFunc,
+  allowSelfNesting?: boolean,
 }
 export interface FuncArg extends ValueField {
   isOptional?: boolean,


### PR DESCRIPTION
Example use case:
Say I want to add 3 numbers together, but my sole addition function only accepts 2 arguments. I don't want to have to create a new function that accepts 3 arguments in order to say Add ( 1 + 2 + 3 ). Rather, I should be able to say Add ( Add ( 1 + 2 ) + 3 ).
There are many functions that would be silly to allow within their own arguments by default -- uppercase ( uppercase ( "abc" ) ) is one example. So we also don't want to simply change the default behavior.