### PR TITLE
Fix is_empty and is_not_empty in spel converter

### DIFF
--- a/modules/import/spel.js
+++ b/modules/import/spel.js
@@ -593,8 +593,10 @@ const convertToTree = (spel, conv, config, meta, parentSpel = null) => {
       opKey = "is_not_null";
     } else if (op == "le" && spel.children[1].type == "string" && spel.children[1].val == "") {
       opKey = "is_empty";
+      opKeys = ["is_empty"];
     } else if (op == "gt" && spel.children[1].type == "string" && spel.children[1].val == "") {
       opKey = "is_not_empty";
+      opKeys = ["is_not_empty"];
     } else if (op == "between") {
       opKey = "between";
       opKeys = ["between"];


### PR DESCRIPTION
Currently, the `is_empty` and `is_not_empty` is rendered in the UI when converting from SpEL expression. For example: if you try to render the `user.firstName <= ''` in the query builder, it doesn't render `is_empty` 

cc: @ukrbublik 

Ref: #714 for more context.