### PR TITLE
Update 'moment' dependency to 2.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "clone": "^2.1.2",
     "immutable": "^3.8.2",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
+    "moment": "^2.29.4",
     "prop-types": "^15.7.2",
     "react-redux": "^7.2.2",
     "redux": "^4.1.0",


### PR DESCRIPTION
`moment` [has released](https://github.com/moment/moment/blob/develop/CHANGELOG.md) a number of security fixes since `2.29.1`. This change updates the dependency to `2.29.4` to include the latest bug and security fixes.