### PR TITLE
Fix validation of bad multiselect value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Fixed `getTotalRulesCountInTree()` == 1 (should be 0) for clear tree (PR #673) (issue #583)
   - Handle validation of bad multiselect value correctly (PR #XXX) (issue #674)
     Remove bad values from list, don't unset whole value.
+    Added config `removeInvalidMultiSelectValuesOnLoad` (true by default, false for AntDesign)
 - 5.1.2
   - Added config `removeIncompleteRulesOnLoad` (default false) (PR #661) (issue #642)
   - Fix error when using same field for comparison as argument of function (PR #662) (issue #612)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - Support React 18. Migrate to x-date-pickers. (PR #734) (issues #710, #732)
   - Add path property at `index.d.ts` (PR #671) (issue #669)
   - Fixed `getTotalRulesCountInTree()` == 1 (should be 0) for clear tree (PR #673) (issue #583)
-  - Handle validation of bad multiselect value correctly (PR #XXX) (issue #674)
+  - Handle validation of bad multiselect value correctly (PR #733) (issue #674)
     Remove bad values from list, don't unset whole value.
     Added config `removeInvalidMultiSelectValuesOnLoad` (true by default, false for AntDesign)
 - 5.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
   - ! Breaking change: `children1` is now array in result of `getTree()` to preserve items order (PR #672) (issues #589, #670)
     `Utils.getTree(tree, true, false)` will behave same as before this change.
   - Support React 18. Migrate to x-date-pickers. (PR #734) (issues #710, #732)
+  - Add path property at `index.d.ts` (PR #671) (issue #669)
+  - Fixed `getTotalRulesCountInTree()` == 1 (should be 0) for clear tree (PR #673) (issue #583)
+  - Handle validation of bad multiselect value correctly (PR #XXX) (issue #674)
+    Remove bad values from list, don't unset whole value.
 - 5.1.2
   - Added config `removeIncompleteRulesOnLoad` (default false) (PR #661) (issue #642)
   - Fix error when using same field for comparison as argument of function (PR #662) (issue #612)

--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -312,7 +312,9 @@ Behaviour settings:
 |showLock |false |Show "Lock" switch for rules and groups to make them read-only ("admin mode") +
   NOTE: To preserve read-only state of rules in JsonLogic, please use `jsonLogic.add_operation("locked", v => v);` in your code
 |canDeleteLocked |false |Show "Delete" button for locked rule?
-|removeIncompleteRulesOnLoad |false |Remove incomplete rules (w/o value) in `Utils.checkTree()`?
+|removeIncompleteRulesOnLoad |false |Remove incomplete rules (w/o value) during validation in `Utils.checkTree()`?
+|removeInvalidMultiSelectValuesOnLoad |true |Remove values that are not in `listValues` during validation in `Utils.checkTree()`? +
+  By default `true`, but `false` for AntDesign as can be removed manually
 |===
 
 TIP: For fully read-only mode use these settings:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ const queryValue = {"id": QbUtils.uuid(), "type": "group"};
 
 class DemoQueryBuilder extends Component {
     state = {
-      tree: QbUtils.loadTree(queryValue),
+      tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), config),
       config: config
     };
     
@@ -304,7 +304,7 @@ const queryValue: JsonGroup = { id: QbUtils.uuid(), type: "group" };
 
 export const Demo: React.FC = () => {
   const [state, setState] = useState({
-    tree: QbUtils.loadTree(queryValue),
+    tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), config),
     config: config
   });
 
@@ -407,7 +407,7 @@ Wrapping in `div.query-builder-container` is necessary if you put query builder 
   Tip: Use `light = false` in case if you want to store query value in your state in JS format and pass it as `value` of `<Query>` after applying `loadTree()` (which is not recommended because of double conversion). See issue [#190](https://github.com/ukrbublik/react-awesome-query-builder/issues/190)
   #### loadTree (jsValue, config) -> Immutable
   Convert query value from JS format to internal Immutable format. 
-  You can use it to load saved value from backend and pass as `value` prop to `<Query>`.
+  You can use it to load saved value from backend and pass as `value` prop to `<Query>` (don't forget to also apply `checkTree()`).
   #### checkTree (immutableValue, config) -> Immutable
   Validate query value corresponding to config. 
   Invalid parts of query (eg. if field was removed from config) will be always deleted. 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ const queryValue = {"id": QbUtils.uuid(), "type": "group"};
 
 class DemoQueryBuilder extends Component {
     state = {
-      tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), config),
+      tree: QbUtils.loadTree(queryValue),
       config: config
     };
     
@@ -304,7 +304,7 @@ const queryValue: JsonGroup = { id: QbUtils.uuid(), type: "group" };
 
 export const Demo: React.FC = () => {
   const [state, setState] = useState({
-    tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), config),
+    tree: QbUtils.loadTree(queryValue),
     config: config
   });
 
@@ -407,7 +407,7 @@ Wrapping in `div.query-builder-container` is necessary if you put query builder 
   Tip: Use `light = false` in case if you want to store query value in your state in JS format and pass it as `value` of `<Query>` after applying `loadTree()` (which is not recommended because of double conversion). See issue [#190](https://github.com/ukrbublik/react-awesome-query-builder/issues/190)
   #### loadTree (jsValue, config) -> Immutable
   Convert query value from JS format to internal Immutable format. 
-  You can use it to load saved value from backend and pass as `value` prop to `<Query>` (don't forget to also apply `checkTree()`).
+  You can use it to load saved value from backend and pass as `value` prop to `<Query>`.
   #### checkTree (immutableValue, config) -> Immutable
   Validate query value corresponding to config. 
   Invalid parts of query (eg. if field was removed from config) will be always deleted. 

--- a/examples/demo/index.tsx
+++ b/examples/demo/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import {
   Query, Builder, Utils, 
   //types:
@@ -63,7 +63,7 @@ interface DemoQueryBuilderMemo {
 }
 
 const DemoQueryBuilder: React.FC = () => {
-  const memo: DemoQueryBuilderMemo = {};
+  const memo: React.MutableRefObject<DemoQueryBuilderMemo> = useRef({});
 
   const [state, setState] = useState<DemoQueryBuilderState>({
     tree: initTree, 
@@ -149,7 +149,7 @@ const DemoQueryBuilder: React.FC = () => {
   };
 
   const renderBuilder = useCallback((bprops: BuilderProps) => {
-    memo._actions = bprops.actions;
+    memo.current._actions = bprops.actions;
     return (
       <div className="query-builder-container" style={{padding: "10px"}}>
         <div className="query-builder qb-lite">
@@ -162,13 +162,13 @@ const DemoQueryBuilder: React.FC = () => {
   const onChange = useCallback((immutableTree: ImmutableTree, config: Config, actionMeta?: ActionMeta) => {
     if (actionMeta)
       console.info(actionMeta);
-    memo.immutableTree = immutableTree;
-    memo.config = config;
+    memo.current.immutableTree = immutableTree;
+    memo.current.config = config;
     updateResult();
   }, []);
 
   const updateResult = throttle(() => {
-    setState(prevState => ({...prevState, tree: memo.immutableTree, config: memo.config}));
+    setState(prevState => ({...prevState, tree: memo.current.immutableTree, config: memo.current.config}));
   }, 100);
 
   // Demonstrates how actions can be called programmatically
@@ -185,30 +185,30 @@ const DemoQueryBuilder: React.FC = () => {
     ];
 
     // Change root group to NOT OR
-    memo._actions.setNot(rootPath, true);
-    memo._actions.setConjunction(rootPath, "OR");
+    memo.current._actions.setNot(rootPath, true);
+    memo.current._actions.setConjunction(rootPath, "OR");
 
     // Move first item
     if (!isEmptyTree) {
-      memo._actions.moveItem(firstPath, lastPath, "before");
+      memo.current._actions.moveItem(firstPath, lastPath, "before");
     }
 
     // Remove last rule
     if (!isEmptyTree) {
-      memo._actions.removeRule(lastPath);
+      memo.current._actions.removeRule(lastPath);
     }
 
     // Change first rule to `num between 2 and 4`
     if (!isEmptyTree) {
-      memo._actions.setField(firstPath, "num");
-      memo._actions.setOperator(firstPath, "between");
-      memo._actions.setValueSrc(firstPath, 0, "value");
-      memo._actions.setValue(firstPath, 0, 2, "number");
-      memo._actions.setValue(firstPath, 1, 4, "number");
+      memo.current._actions.setField(firstPath, "num");
+      memo.current._actions.setOperator(firstPath, "between");
+      memo.current._actions.setValueSrc(firstPath, 0, "value");
+      memo.current._actions.setValue(firstPath, 0, 2, "number");
+      memo.current._actions.setValue(firstPath, 1, 4, "number");
     }
 
     // Add rule `login == "denis"`
-    memo._actions.addRule(
+    memo.current._actions.addRule(
       rootPath,
       {
         field: "user.login",
@@ -220,7 +220,7 @@ const DemoQueryBuilder: React.FC = () => {
     );
 
     // Add rule `login == firstName`
-    memo._actions.addRule(
+    memo.current._actions.addRule(
       rootPath,
       {
         field: "user.login",
@@ -231,7 +231,7 @@ const DemoQueryBuilder: React.FC = () => {
     );
 
     // Add rule-group `cars` with `year == 2021`
-    memo._actions.addRule(
+    memo.current._actions.addRule(
       rootPath,
       {
         field: "cars",
@@ -252,7 +252,7 @@ const DemoQueryBuilder: React.FC = () => {
     );
 
     // Add group with `slider == 40` and subgroup `slider < 20`
-    memo._actions.addGroup(
+    memo.current._actions.addGroup(
       rootPath,
       {
         conjunction: "AND"

--- a/examples/demo/index.tsx
+++ b/examples/demo/index.tsx
@@ -22,8 +22,8 @@ const loadedConfig = loadConfig(initialSkin);
 let initValue: JsonTree = loadedInitValue && Object.keys(loadedInitValue).length > 0 ? loadedInitValue as JsonTree : emptyInitValue;
 const initLogic: JsonLogicTree = loadedInitLogic && Object.keys(loadedInitLogic).length > 0 ? loadedInitLogic as JsonLogicTree : undefined;
 let initTree: ImmutableTree;
-//initTree = loadTree(initValue);
-initTree = loadFromJsonLogic(initLogic, loadedConfig); // <- this will work same  
+//initTree = checkTree(loadTree(initValue), loadedConfig);
+initTree = checkTree(loadFromJsonLogic(initLogic, loadedConfig), loadedConfig); // <- this will work same  
 
 
 // Trick to hot-load new config when you edit `config.tsx`
@@ -124,7 +124,7 @@ const DemoQueryBuilder: React.FC = () => {
     const [tree, spelErrors] = loadFromSpel(state.spelStr, state.config);
     setState({
       ...state, 
-      tree: tree || state.tree,
+      tree: tree ? checkTree(tree, state.config) : state.tree,
       spelErrors
     });
   };
@@ -135,7 +135,8 @@ const DemoQueryBuilder: React.FC = () => {
     setState({
       ...state,
       skin,
-      config
+      config,
+      tree: checkTree(state.tree, config)
     });
     window._initialSkin = skin;
   };

--- a/examples/demo/index.tsx
+++ b/examples/demo/index.tsx
@@ -12,7 +12,7 @@ import Immutable from "immutable";
 import clone from "clone";
 
 const stringify = JSON.stringify;
-const {elasticSearchFormat, queryBuilderFormat, jsonLogicFormat, queryString, _mongodbFormat, _sqlFormat, _spelFormat, getTree, checkTree, loadTree, uuid, loadFromJsonLogic, loadFromSpel, isValidTree} = Utils;
+const {elasticSearchFormat, queryBuilderFormat, jsonLogicFormat, queryString, _mongodbFormat, _sqlFormat, _spelFormat, getTree, loadTree, uuid, loadFromJsonLogic, loadFromSpel, checkTree, isValidTree} = Utils;
 const preStyle = { backgroundColor: "darkgrey", margin: "10px", padding: "10px" };
 const preErrorStyle = { backgroundColor: "lightpink", margin: "10px", padding: "10px" };
 
@@ -22,8 +22,8 @@ const loadedConfig = loadConfig(initialSkin);
 let initValue: JsonTree = loadedInitValue && Object.keys(loadedInitValue).length > 0 ? loadedInitValue as JsonTree : emptyInitValue;
 const initLogic: JsonLogicTree = loadedInitLogic && Object.keys(loadedInitLogic).length > 0 ? loadedInitLogic as JsonLogicTree : undefined;
 let initTree: ImmutableTree;
-//initTree = checkTree(loadTree(initValue), loadedConfig);
-initTree = checkTree(loadFromJsonLogic(initLogic, loadedConfig), loadedConfig); // <- this will work same  
+//initTree = loadTree(initValue);
+initTree = loadFromJsonLogic(initLogic, loadedConfig); // <- this will work same  
 
 
 // Trick to hot-load new config when you edit `config.tsx`
@@ -124,7 +124,7 @@ const DemoQueryBuilder: React.FC = () => {
     const [tree, spelErrors] = loadFromSpel(state.spelStr, state.config);
     setState({
       ...state, 
-      tree: tree ? checkTree(tree, state.config) : state.tree,
+      tree: tree || state.tree,
       spelErrors
     });
   };
@@ -135,8 +135,7 @@ const DemoQueryBuilder: React.FC = () => {
     setState({
       ...state,
       skin,
-      config,
-      tree: checkTree(state.tree, config)
+      config
     });
     window._initialSkin = skin;
   };

--- a/examples/demo/index.tsx
+++ b/examples/demo/index.tsx
@@ -12,7 +12,7 @@ import Immutable from "immutable";
 import clone from "clone";
 
 const stringify = JSON.stringify;
-const {elasticSearchFormat, queryBuilderFormat, jsonLogicFormat, queryString, _mongodbFormat, _sqlFormat, _spelFormat, getTree, loadTree, uuid, loadFromJsonLogic, loadFromSpel, checkTree, isValidTree} = Utils;
+const {elasticSearchFormat, queryBuilderFormat, jsonLogicFormat, queryString, _mongodbFormat, _sqlFormat, _spelFormat, getTree, checkTree, loadTree, uuid, loadFromJsonLogic, loadFromSpel, isValidTree} = Utils;
 const preStyle = { backgroundColor: "darkgrey", margin: "10px", padding: "10px" };
 const preErrorStyle = { backgroundColor: "lightpink", margin: "10px", padding: "10px" };
 

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,8 +1,8 @@
 
 import React, {Component} from "react";
 import ReactDOM from "react-dom";
-import Demo from "./demo";
-import DemoSwitch from "./demo_switch";
+const Demo = React.lazy(() => import("./demo"));
+const DemoSwitch = React.lazy(() => import("./demo_switch"));
 import {
   BrowserRouter,
   Routes,
@@ -18,8 +18,8 @@ const rootElement = window.document.getElementById("root");
 ReactDOM.render((
   <BrowserRouter basename={location.host == "ukrbublik.github.io" ? "/react-awesome-query-builder" : "/"}>
     <Routes>
-      <Route path="/switch" element={<DemoSwitch />} />
-      <Route path="*" element={<Demo />} />
+      <Route path="/switch" element={<React.Suspense fallback={<>...</>}><DemoSwitch /></React.Suspense>} />
+      <Route path="*" element={<React.Suspense fallback={<>...</>}><Demo /></React.Suspense>} />
     </Routes>
   </BrowserRouter>
 ), rootElement);

--- a/modules/actions/tree.js
+++ b/modules/actions/tree.js
@@ -12,7 +12,8 @@ import Immutable from "immutable";
  */
 export const setTree = (config, tree) => ({
   type: constants.SET_TREE,
-  tree: tree
+  tree: tree,
+  config: config
 });
 
 /**

--- a/modules/components/Query.jsx
+++ b/modules/components/Query.jsx
@@ -42,7 +42,8 @@ class Query extends Component {
   shouldComponentUpdate = liteShouldComponentUpdate(this, {
     tree: (nextValue) => {
       if (nextValue === this.oldValidatedTree && this.oldValidatedTree === this.validatedTree) {
-        // got dispatched value
+        // Got value dispatched from QueryContainer
+        // Ignore, because we've just rendered it
         return false;
       }
       return true;

--- a/modules/components/Query.jsx
+++ b/modules/components/Query.jsx
@@ -1,26 +1,22 @@
 import React, { PureComponent } from "react";
+import {connect} from "react-redux";
+import context from "../stores/context";
 import PropTypes from "prop-types";
 import * as actions from "../actions";
-import {fixPathsInTree} from "../utils/treeUtils";
 import {immutableEqual} from "../utils/stuff";
 import {useOnPropsChanged, bindActionCreators} from "../utils/reactUtils";
-import {validateTree} from "../utils/validation";
+import {validateAndFixTree} from "../utils/validation";
 
 
-export const validateAndFixTree = (newTree, _oldTree, newConfig, oldConfig) => {
-  let tree = validateTree(newTree, _oldTree, newConfig, oldConfig);
-  tree = fixPathsInTree(tree);
-  return tree;
-};
-
-
-export default class Query extends PureComponent {
+class Query extends PureComponent {
   static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func,
     renderBuilder: PropTypes.func,
     tree: PropTypes.any, //instanceOf(Immutable.Map)
     //dispatch: PropTypes.func.isRequired,
+    //__isInternalValueChange
+    //__lastAction
   };
 
   constructor(props) {
@@ -29,7 +25,9 @@ export default class Query extends PureComponent {
 
     this._updateActions(props);
 
-    this.validatedTree = this.validateTree(props, props);
+    //tip: already validated with QueryContainer
+    this.validatedTree = props.tree;
+
     //props.onChange && props.onChange(this.validatedTree, props.config);
   }
 
@@ -74,3 +72,23 @@ export default class Query extends PureComponent {
     return renderBuilder(builderProps);
   }
 }
+
+
+const ConnectedQuery = connect(
+  (state) => {
+    return {
+      tree: state.tree,
+      __isInternalValueChange: state.__isInternalValueChange,
+      __lastAction: state.__lastAction,
+    };
+  },
+  null,
+  null,
+  {
+    context
+  }
+)(Query);
+ConnectedQuery.displayName = "ConnectedQuery";
+
+
+export default ConnectedQuery;

--- a/modules/components/Query.jsx
+++ b/modules/components/Query.jsx
@@ -5,11 +5,7 @@ import PropTypes from "prop-types";
 import * as actions from "../actions";
 import {immutableEqual} from "../utils/stuff";
 import {useOnPropsChanged, liteShouldComponentUpdate, bindActionCreators} from "../utils/reactUtils";
-import {validateAndFixTree} from "../utils/validation";
 
-const validateTree = (props, oldProps) => {
-  return validateAndFixTree(props.tree, oldProps.tree, props.config, oldProps.config);
-};
 
 class Query extends Component {
   static propTypes = {
@@ -32,9 +28,7 @@ class Query extends Component {
     // For preventive validation (tree and config consistency)
     // When config has chnaged from QueryContainer, 
     //  but new dispatched validated tree value is not in redux store yet (tree prop is old)
-    this.validatedTree = props.getMemoizedTree(props.config, props.tree, () => 
-      validateTree(props, props)
-    );
+    this.validatedTree = props.getMemoizedTree(props.config, props.tree);
     this.oldValidatedTree = this.validatedTree;
 
     //props.onChange && props.onChange(this.validatedTree, props.config);
@@ -46,13 +40,13 @@ class Query extends Component {
   }
 
   shouldComponentUpdate = liteShouldComponentUpdate(this, {
-    tree: (nextValue, prevValue, state) => {
+    tree: (nextValue) => {
       if (nextValue === this.oldValidatedTree && this.oldValidatedTree === this.validatedTree) {
         // got dispatched value
         return false;
       }
       return true;
-    },
+    }
   });
 
   onPropsChanged(nextProps) {
@@ -66,9 +60,7 @@ class Query extends Component {
     this.validatedTree = newTree;
     if (oldConfig !== newConfig) {
       this._updateActions(nextProps);
-      this.validatedTree = nextProps.getMemoizedTree(newConfig, newTree, () => 
-        validateTree(nextProps, this.props)
-      );
+      this.validatedTree = nextProps.getMemoizedTree(newConfig, newTree, oldConfig);
     }
 
     const validatedTreeChanged = !immutableEqual(this.validatedTree, this.oldValidatedTree);

--- a/modules/components/QueryContainer.jsx
+++ b/modules/components/QueryContainer.jsx
@@ -8,7 +8,7 @@ import * as actions from "../actions";
 import {createConfigMemo} from "../utils/configUtils";
 import {immutableEqual} from "../utils/stuff";
 import {defaultRoot} from "../utils/defaultUtils";
-import {validateAndFixTree, createValidationMemo} from "../utils/validation";
+import {createValidationMemo} from "../utils/validation";
 import {liteShouldComponentUpdate, useOnPropsChanged} from "../utils/reactUtils";
 import ConnectedQuery from "./Query";
 
@@ -37,9 +37,7 @@ export default class QueryContainer extends Component {
     
     const config = this.getMemoizedConfig(props);
     const tree = props.value;
-    const validatedTree = this.getMemoizedTree(config, tree, () => 
-      validateAndFixTree(tree, null, config, config)
-    );
+    const validatedTree = this.getMemoizedTree(config, tree);
 
     const reducer = treeStoreReducer(config, validatedTree, this.getMemoizedTree);
     const store = createStore(reducer);
@@ -70,9 +68,7 @@ export default class QueryContainer extends Component {
     }
     
     if (isTreeChanged || isConfigChanged) {
-      const validatedTree = this.getMemoizedTree(nextConfig, currentTree, () => 
-        validateAndFixTree(currentTree, null, nextConfig, oldConfig)
-      );
+      const validatedTree = this.getMemoizedTree(nextConfig, currentTree, oldConfig);
       return Promise.resolve().then(() => {
         this.state.store.dispatch(
           actions.tree.setTree(nextConfig, validatedTree)

--- a/modules/config/antd/index.js
+++ b/modules/config/antd/index.js
@@ -62,6 +62,8 @@ const settings = {
     ...BasicConfig.settings.locale,
     antd: en_US,
   },
+
+  removeInvalidMultiSelectValuesOnLoad: false, // can be removed manually in UI
 };
 
 

--- a/modules/config/default.js
+++ b/modules/config/default.js
@@ -48,7 +48,8 @@ export const settings = {
   forceShowConj: false,
   canShortMongoQuery: true,
   removeEmptyGroupsOnLoad: true,
-  removeIncompleteRulesOnLoad: false,
+  removeIncompleteRulesOnLoad: true,
+  removeInvalidMultiSelectValuesOnLoad: true,
   groupActionsPosition: "topRight", // oneOf [topLeft, topCenter, topRight, bottomLeft, bottomCenter, bottomRight]
   setOpOnChangeField: ["keep", "default"], // 'default' (default if present), 'keep' (keep prev from last field), 'first', 'none'
   groupOperators: ["some", "all", "none"],

--- a/modules/export/elasticSearch.js
+++ b/modules/export/elasticSearch.js
@@ -236,6 +236,8 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
   // handle if value 0 has multiple values like a select in a array
   const widget = getWidgetForFieldOp(config, fieldName, op, valueSrc);
   const widgetConfig = config.widgets[widget];
+  if (!widgetConfig)
+    return undefined; // unknown widget
   const { elasticSearchFormatValue } = widgetConfig;
 
   /** In most cases the queryType will be static however in some casese (like between) the query type will change

--- a/modules/export/sql.js
+++ b/modules/export/sql.js
@@ -219,7 +219,11 @@ const formatValue = (meta, config, currentValue, valueSrc, valueType, fieldWidge
       }
       ret = fn(...args);
     } else {
-      ret = SqlString.escape(currentValue);
+      if (Array.isArray(currentValue)) {
+        ret = currentValue.map(v => SqlString.escape(v));
+      } else {
+        ret = SqlString.escape(currentValue);
+      }
     }
   }
   return ret;

--- a/modules/hooks/useListValuesAutocomplete.jsx
+++ b/modules/hooks/useListValuesAutocomplete.jsx
@@ -167,10 +167,16 @@ const useListValuesAutocomplete = ({
     } else {
       if (multiple) {
         const options = option;
-        let newSelectedListValues = options.map(o =>
-          o.value != null ? o : getListValue(o, listValues)
-        );
-        let newSelectedValues = newSelectedListValues.filter(o => o !== undefined).map(o => o.value);
+        let newSelectedListValues = options.map((o, i) => {
+          const item = o.value != null ? o : getListValue(o, listValues);
+          // AntDesign puts array of labels in `_e` (`option` is array of objects, but custom option is always `{}`)
+          // MUI puts array of labels in `option`
+          const customItem = allowCustomValues && !item ? (Array.isArray(_e) ? _e[i] : o) : null;
+          return item || customItem;
+        });
+        let newSelectedValues = newSelectedListValues
+          .filter(o => o !== undefined)
+          .map(o => (o.value !== undefined ? o.value : o));
         if (!newSelectedValues.length)
           newSelectedValues = undefined; //not allow []
         setValue(newSelectedValues, newSelectedListValues);

--- a/modules/hooks/useListValuesAutocomplete.jsx
+++ b/modules/hooks/useListValuesAutocomplete.jsx
@@ -170,7 +170,7 @@ const useListValuesAutocomplete = ({
         let newSelectedListValues = options.map(o =>
           o.value != null ? o : getListValue(o, listValues)
         );
-        let newSelectedValues = newSelectedListValues.map(o => o.value);
+        let newSelectedValues = newSelectedListValues.filter(o => o !== undefined).map(o => o.value);
         if (!newSelectedValues.length)
           newSelectedValues = undefined; //not allow []
         setValue(newSelectedValues, newSelectedListValues);

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -185,6 +185,7 @@ export interface Utils {
   simulateAsyncFetch(all: AsyncFetchListValues, pageSize?: number, delay?: number): AsyncFetchListValuesFn;
   // config utils
   ConfigUtils: {
+    extendConfig(config: Config): Config;
     getFieldConfig(config: Config, field: string): Field | null;
     getFuncConfig(config: Config, func: string): Func | null;
     getFuncArgConfig(config: Config, func: string, arg: string): FuncArg | null;

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -856,10 +856,12 @@ export interface BehaviourSettings {
   maxNumberOfRules?: Number,
   maxNumberOfCases?: Number,
   showErrorMessage?: boolean,
+
   canShortMongoQuery?: boolean,
   convertableWidgets?: TypedMap<Array<string>>,
   removeEmptyGroupsOnLoad?: boolean,
   removeIncompleteRulesOnLoad?: boolean,
+  removeInvalidMultiSelectValuesOnLoad?: boolean,
 }
 
 export interface OtherSettings {

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -856,7 +856,6 @@ export interface BehaviourSettings {
   maxNumberOfRules?: Number,
   maxNumberOfCases?: Number,
   showErrorMessage?: boolean,
-
   canShortMongoQuery?: boolean,
   convertableWidgets?: TypedMap<Array<string>>,
   removeEmptyGroupsOnLoad?: boolean,

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -703,9 +703,13 @@ const getActionMeta = (action, state) => {
  * @param {Immutable.Map} state
  * @param {object} action
  */
-export default (config) => {
+export default (config, tree, getMemoizedTree) => {
   const emptyTree = defaultRoot(config);
-  const emptyState = Object.assign({}, {tree: emptyTree}, emptyDrag);
+  const initTree = tree || emptyTree;
+  const emptyState = {
+    tree: initTree, 
+    ...emptyDrag
+  };
     
   return (state = emptyState, action) => {
     const unset = {__isInternalValueChange: undefined, __lastAction: undefined};
@@ -714,7 +718,9 @@ export default (config) => {
 
     switch (action.type) {
     case constants.SET_TREE: {
-      const validatedTree = validateAndFixTree(action.tree, state.tree, action.config || config, config);
+      const validatedTree = getMemoizedTree(action.config, action.tree, () => 
+        validateAndFixTree(action.tree, state.tree, action.config, action.config)
+      );
       set.tree = validatedTree;
       break;
     }

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -18,7 +18,7 @@ import {
   getNewValueForFieldOp
 } from "../utils/ruleUtils";
 import {deepEqual, defaultValue, applyToJS} from "../utils/stuff";
-import {validateValue, validateAndFixTree} from "../utils/validation";
+import {validateValue} from "../utils/validation";
 import omit from "lodash/omit";
 import mapValues from "lodash/mapValues";
 

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -718,9 +718,7 @@ export default (config, tree, getMemoizedTree) => {
 
     switch (action.type) {
     case constants.SET_TREE: {
-      const validatedTree = getMemoizedTree(action.config, action.tree, () => 
-        validateAndFixTree(action.tree, state.tree, action.config, action.config)
-      );
+      const validatedTree = getMemoizedTree(action.config, action.tree);
       set.tree = validatedTree;
       break;
     }

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -18,7 +18,7 @@ import {
   getNewValueForFieldOp
 } from "../utils/ruleUtils";
 import {deepEqual, defaultValue, applyToJS} from "../utils/stuff";
-import {validateValue} from "../utils/validation";
+import {validateValue, validateAndFixTree} from "../utils/validation";
 import omit from "lodash/omit";
 import mapValues from "lodash/mapValues";
 
@@ -714,7 +714,8 @@ export default (config) => {
 
     switch (action.type) {
     case constants.SET_TREE: {
-      set.tree = action.tree;
+      const validatedTree = validateAndFixTree(action.tree, state.tree, action.config || config, config);
+      set.tree = validatedTree;
       break;
     }
 

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -500,14 +500,13 @@ const setValue = (state, path, delta, value, valueType, config, asyncListValues,
   const operatorCardinality = operator ? defaultValue(operatorConfig.cardinality, 1) : null;
 
   const isEndValue = false;
-  const canFix = false;
   const calculatedValueType = valueType || calculateValueType(value, valueSrc, config);
+  const canFix = false;
   const [validateError, fixedValue] = validateValue(
     config, field, field, operator, value, calculatedValueType, valueSrc, asyncListValues, canFix, isEndValue
   );
-    
   const isValid = !validateError;
-  if (isValid && fixedValue !== value) {
+  if (fixedValue !== value) {
     // eg, get exact value from listValues (not string)
     value = fixedValue;
   }

--- a/modules/utils/configUtils.js
+++ b/modules/utils/configUtils.js
@@ -5,16 +5,68 @@ import moment from "moment";
 import {normalizeListValues, mergeArraysSmart} from "./stuff";
 import {getWidgetForFieldOp} from "./ruleUtils";
 import clone from "clone";
+import pick from "lodash/pick";
 
 
-export const extendConfig = (config) => {
+const configKeys = ["conjunctions", "fields", "types", "operators", "widgets", "settings", "funcs"];
+
+const pickConfig = (props) => {
+  return pick(props, configKeys);
+};
+
+export const createConfigMemo = () => {
+  const configStore = new Map();
+  const maxSize = 2; // current and prev
+  let configId = 0;
+
+  const extendAndStore = (config) => {
+    const extendedConfig = extendConfig(config, ++configId);
+    if ((configStore.size + 1) > maxSize) {
+      configStore.delete(configStore.keys()[0]);
+    }
+    configStore.set(config, extendedConfig);
+    return extendedConfig;
+  };
+
+  const findExtended = (findConfig) => {
+    // strict find:
+    // return configStore.get(findConfig) || configStore.values().find(ec => ec === findConfig);
+
+    for (const savedConfig of configStore.keys()) {
+      const found = configKeys.map(k => savedConfig[k] === findConfig[k]).filter(v => !v).length === 0;
+      if (found) {
+        return configStore.get(savedConfig);
+      }
+    }
+
+    for (const extendedConfig of configStore.values()) {
+      const found = configKeys.map(k => extendedConfig[k] === findConfig[k]).filter(v => !v).length === 0;
+      if (found) {
+        return extendedConfig;
+      }
+    }
+
+    return null;
+  };
+
+  const findOrExtend = (config) => {
+    return findExtended(config) || extendAndStore(config);
+  };
+  
+  return (props) => findOrExtend(pickConfig(props));
+};
+
+
+
+export const extendConfig = (config, configId) => {
   //operators, defaultOperator - merge
   //widgetProps (including valueLabel, valuePlaceholder, hideOperator, operatorInlineLabel) - concrete by widget
 
-  if (config.__extended) {
+  if (config.__configId) {
     return config;
   }
-    
+  
+  config = {...config};
   config.settings = merge({}, defaultSettings, config.settings);
   config._fieldsCntByType = {};
   config._funcsCntByType = {};
@@ -31,10 +83,10 @@ export const extendConfig = (config) => {
 
   moment.locale(config.settings.locale.moment);
 
-  Object.defineProperty(config, "__extended", {
+  Object.defineProperty(config, "__configId", {
     enumerable: false,
     writable: false,
-    value: true
+    value: configId
   });
 
   return config;

--- a/modules/utils/defaultUtils.js
+++ b/modules/utils/defaultUtils.js
@@ -57,7 +57,9 @@ export const defaultRuleProperties = (config, parentRuleGroupPath = null, item =
   }
   
   if (field && operator) {
-    let {newValue, newValueSrc, newValueType, newValueError} = getNewValueForFieldOp(config, config, current, field, operator, "operator", false);
+    let {newValue, newValueSrc, newValueType, newValueError} = getNewValueForFieldOp(
+      config, config, current, field, operator, "operator", false
+    );
     current = current
       .set("value", newValue)
       .set("valueSrc", newValueSrc)

--- a/modules/utils/defaultUtils.js
+++ b/modules/utils/defaultUtils.js
@@ -102,10 +102,6 @@ export const defaultRule = (id, config) => ({
 });
 
 export const defaultRoot = (config) => {
-  if (config.tree) {
-    return new Immutable.Map(config.tree);
-  }
-  
   return new Immutable.Map({
     type: "group",
     id: uuid(),

--- a/modules/utils/reactUtils.js
+++ b/modules/utils/reactUtils.js
@@ -6,20 +6,20 @@ export const liteShouldComponentUpdate = (self, config) => (nextProps, nextState
   const prevProps = self.props;
   const prevState = self.state;
 
-  let should = nextProps != prevProps || nextState != prevState;
+  let should = nextProps !== prevProps || nextState !== prevState;
   if (should) {
-    if (prevState == nextState && prevProps != nextProps) {
+    if (prevState === nextState && prevProps !== nextProps) {
       let chs = [];
       for (let k in nextProps) {
         let changed = (nextProps[k] != prevProps[k]);
         if (changed) {
-          if (config[k] == "ignore")
+          if (config[k] === "ignore")
             changed = false;
-          else if (config[k] == "shallow_deep")
+          else if (config[k] === "shallow_deep")
             changed = !shallowEqual(nextProps[k], prevProps[k], true);
-          else if (config[k] == "shallow")
+          else if (config[k] === "shallow")
             changed = !shallowEqual(nextProps[k], prevProps[k]);
-          else if (typeof config[k] == "function")
+          else if (typeof config[k] === "function")
             changed = config[k](nextProps[k], prevProps[k], nextState);
         }
         if (changed)

--- a/modules/utils/reactUtils.js
+++ b/modules/utils/reactUtils.js
@@ -6,20 +6,20 @@ export const liteShouldComponentUpdate = (self, config) => (nextProps, nextState
   const prevProps = self.props;
   const prevState = self.state;
 
-  let should = nextProps !== prevProps || nextState !== prevState;
+  let should = nextProps != prevProps || nextState != prevState;
   if (should) {
-    if (prevState === nextState && prevProps !== nextProps) {
+    if (prevState == nextState && prevProps != nextProps) {
       let chs = [];
       for (let k in nextProps) {
         let changed = (nextProps[k] != prevProps[k]);
         if (changed) {
-          if (config[k] === "ignore")
+          if (config[k] == "ignore")
             changed = false;
-          else if (config[k] === "shallow_deep")
+          else if (config[k] == "shallow_deep")
             changed = !shallowEqual(nextProps[k], prevProps[k], true);
-          else if (config[k] === "shallow")
+          else if (config[k] == "shallow")
             changed = !shallowEqual(nextProps[k], prevProps[k]);
-          else if (typeof config[k] === "function")
+          else if (typeof config[k] == "function")
             changed = config[k](nextProps[k], prevProps[k], nextState);
         }
         if (changed)

--- a/modules/utils/ruleUtils.js
+++ b/modules/utils/ruleUtils.js
@@ -89,14 +89,19 @@ export const getNewValueForFieldOp = function (config, oldConfig = null, current
         config, newField, newField, newOperator, v, vType, vSrc, asyncListValues, canFix, isEndValue
       );
       const isValid = !validateError;
-      if (!isValid && showErrorMessage && changedProp != "field") {
-        // allow bad value
-        // but not on field change - in that case just drop bad value that can't be reused
-        // ? maybe we should also drop bad value on op change?
+      // allow bad value with error message
+      // but not on field change - in that case just drop bad value that can't be reused
+      // ? maybe we should also drop bad value on op change?
+      const fixValue = fixedValue !== v;
+      const dropValue = !isValidSrc || !isValid && (changedProp == "field" || !showErrorMessage && !fixValue);
+      const showValueError = !isValid && showErrorMessage && !dropValue && !fixValue;
+      if (showValueError) {
         valueErrors[i] = validateError;
-      } else if (canFix && fixedValue !== v) {
+      }
+      if (fixValue) {
         valueFixes[i] = fixedValue;
-      } else if (!isValidSrc || !isValid) {
+      }
+      if (dropValue) {
         canReuseValue = false;
         break;
       }

--- a/modules/utils/ruleUtils.js
+++ b/modules/utils/ruleUtils.js
@@ -94,11 +94,11 @@ export const getNewValueForFieldOp = function (config, oldConfig = null, current
         // but not on field change - in that case just drop bad value that can't be reused
         // ? maybe we should also drop bad value on op change?
         valueErrors[i] = validateError;
+      } else if (canFix && fixedValue !== v) {
+        valueFixes[i] = fixedValue;
       } else if (!isValidSrc || !isValid) {
         canReuseValue = false;
         break;
-      } else if (canFix && fixedValue !== v) {
-        valueFixes[i] = fixedValue;
       }
     }
   }

--- a/modules/utils/ruleUtils.js
+++ b/modules/utils/ruleUtils.js
@@ -22,7 +22,7 @@ const selectTypes = [
  * @param {string} changedProp
  * @return {object} - {canReuseValue, newValue, newValueSrc, newValueType, newValueError}
  */
-export const getNewValueForFieldOp = function (config, oldConfig = null, current, newField, newOperator, changedProp = null, canFix = true) {
+export const getNewValueForFieldOp = function (config, oldConfig = null, current, newField, newOperator, changedProp = null, canFix = true, isEndValue = false) {
   if (!oldConfig)
     oldConfig = config;
   const currentField = current.get("field");
@@ -83,18 +83,19 @@ export const getNewValueForFieldOp = function (config, oldConfig = null, current
       let isValidSrc = (valueSources.find(v => v == vSrc) != null);
       if (!isValidSrc && i > 0 && vSrc == null)
         isValidSrc = true; // make exception for range widgets (when changing op from '==' to 'between')
-      const isEndValue = !canFix;
       const asyncListValues = currentAsyncListValues;
       const [validateError, fixedValue] = validateValue(
         config, newField, newField, newOperator, v, vType, vSrc, asyncListValues, canFix, isEndValue
       );
       const isValid = !validateError;
-      // allow bad value with error message
-      // but not on field change - in that case just drop bad value that can't be reused
-      // ? maybe we should also drop bad value on op change?
+      // Allow bad value with error message
+      // But not on field change - in that case just drop bad value that can't be reused
+      // ? Maybe we should also drop bad value on op change?
+      // For bad multiselect value we have both error message + fixed value.
+      //  If we show error message, it will gone on next tree validation
       const fixValue = fixedValue !== v;
       const dropValue = !isValidSrc || !isValid && (changedProp == "field" || !showErrorMessage && !fixValue);
-      const showValueError = !isValid && showErrorMessage && !dropValue && !fixValue;
+      const showValueError = !!validateError && showErrorMessage && !dropValue && !fixValue;
       if (showValueError) {
         valueErrors[i] = validateError;
       }

--- a/modules/utils/stuff.js
+++ b/modules/utils/stuff.js
@@ -344,9 +344,9 @@ export function mergeArraysSmart(arr1, arr2) {
     }, arr1.slice());
 }
 
-const isDev = () => (process && process.env && process.env.NODE_ENV == "development");
+const isDev = () => (typeof process !== "undefined" && process.env && process.env.NODE_ENV == "development");
 
-export const getLogger = (devMode = false) => {
+export const getLogger = (devMode) => {
   const verbose = devMode != undefined ? devMode : isDev(); 
   return verbose ? console : {
     error: () => {},

--- a/modules/utils/stuff.js
+++ b/modules/utils/stuff.js
@@ -346,7 +346,7 @@ export function mergeArraysSmart(arr1, arr2) {
 
 const isDev = () => (typeof process !== "undefined" && process.env && process.env.NODE_ENV == "development");
 
-export const getLogger = (devMode) => {
+export const getLogger = (devMode = false) => {
   const verbose = devMode != undefined ? devMode : isDev(); 
   return verbose ? console : {
     error: () => {},

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -250,21 +250,20 @@ export const validateValue = (config, leftField, field, operator, value, valueTy
     console.warn("[RAQB validate]", `Field ${field}: ${validError}`);
   }
 
-  return [validError, validError ? value : fixedValue];
+  return [validError, canFix ? fixedValue : value];
 };
 
 const validateValueInList = (value, listValues) => {
   const values = List.isList(value) ? value.toJS() : (value instanceof Array ? [...value] : undefined);
   if (values) {
-    for (let i = 0 ; i < values.length ; i++) {
-      const vv = getItemInListValues(listValues, values[i]);
+    return values.reduce(([err, fixed], val) => {
+      const vv = getItemInListValues(listValues, val);
       if (vv == undefined) {
-        return [`Value ${value[i]} is not in list of values`, values];
+        return [err || `Value ${val} is not in list of values`, fixed];
       } else {
-        values[i] = vv.value;
+        return [err, [...fixed, vv.value]];
       }
-    }
-    return [null, values];
+    }, [null, []]);
   } else {
     const vv = getItemInListValues(listValues, value);
     if (vv == undefined) {

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -276,7 +276,7 @@ export const validateValue = (config, leftField, field, operator, value, valueTy
   }
 
   if (isRawValue && validError) {
-    logger.warn("[RAQB validate]", `Field ${field}: ${validError}`);
+    console.warn("[RAQB validate]", `Field ${field}: ${validError}`);
   }
   
   return [validError, fixedValue];

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -4,6 +4,7 @@ import {
 import {getOperatorsForField, getWidgetForFieldOp, getNewValueForFieldOp} from "../utils/ruleUtils";
 import {defaultValue, deepEqual, getItemInListValues, logger} from "../utils/stuff";
 import {defaultOperatorOptions} from "../utils/defaultUtils";
+import {fixPathsInTree} from "../utils/treeUtils";
 import omit from "lodash/omit";
 import { List } from "immutable";
 
@@ -21,6 +22,13 @@ const isTypeOf = (v, type) => {
   if (type == "number" && !isNaN(v))
     return true; //can be casted
   return false;
+};
+
+
+export const validateAndFixTree = (newTree, _oldTree, newConfig, oldConfig) => {
+  let tree = validateTree(newTree, _oldTree, newConfig, oldConfig);
+  tree = fixPathsInTree(tree);
+  return tree;
 };
 
 export const validateTree = (tree, _oldTree, config, oldConfig, removeEmptyGroups, removeIncompleteRules) => {
@@ -248,7 +256,7 @@ export const validateValue = (config, leftField, field, operator, value, valueTy
   }
 
   if (isRawValue && validError) {
-    console.warn("[RAQB validate]", `Field ${field}: ${validError}`);
+    logger.warn("[RAQB validate]", `Field ${field}: ${validError}`);
   }
   
   return [validError, fixedValue];

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -29,7 +29,7 @@ export const createValidationMemo = () => {
   let validatedTree;
   let configId;
 
-  return (config, tree, validateTreeFn) => {
+  return (config, tree, oldConfig) => {
     if (!tree) {
       return null;
     }
@@ -38,7 +38,7 @@ export const createValidationMemo = () => {
     } else {
       configId = config.__configId;
       originalTree = tree;
-      validatedTree = validateTreeFn();
+      validatedTree = validateAndFixTree(tree, null, config, oldConfig || config);
       return validatedTree;
     }
   };

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -2,7 +2,7 @@ import {
   getFieldConfig, getOperatorConfig, getFieldWidgetConfig, getFuncConfig,
 } from "./configUtils";
 import {getOperatorsForField, getWidgetForFieldOp, getNewValueForFieldOp} from "../utils/ruleUtils";
-import {defaultValue, deepEqual, getItemInListValues, logger} from "../utils/stuff";
+import {defaultValue, deepEqual, getItemInListValues, logger, immutableEqual} from "../utils/stuff";
 import {defaultOperatorOptions} from "../utils/defaultUtils";
 import {fixPathsInTree} from "../utils/treeUtils";
 import omit from "lodash/omit";
@@ -24,6 +24,25 @@ const isTypeOf = (v, type) => {
   return false;
 };
 
+export const createValidationMemo = () => {
+  let originalTree;
+  let validatedTree;
+  let configId;
+
+  return (config, tree, validateTreeFn) => {
+    if (!tree) {
+      return null;
+    }
+    if (config.__configId === configId && (immutableEqual(tree, originalTree) || immutableEqual(tree, validatedTree))) {
+      return validatedTree;
+    } else {
+      configId = config.__configId;
+      originalTree = tree;
+      validatedTree = validateTreeFn();
+      return validatedTree;
+    }
+  };
+};
 
 export const validateAndFixTree = (newTree, _oldTree, newConfig, oldConfig) => {
   let tree = validateTree(newTree, _oldTree, newConfig, oldConfig);

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -282,7 +282,7 @@ export const validateValue = (config, leftField, field, operator, value, valueTy
   return [validError, fixedValue];
 };
 
-const validateValueInList = (value, listValues, canFix, isEndValue) => {
+const validateValueInList = (value, listValues, canFix, isEndValue, removeInvalidMultiSelectValuesOnLoad) => {
   const values = List.isList(value) ? value.toJS() : (value instanceof Array ? [...value] : undefined);
   if (values) {
     const [goodValues, badValues] = values.reduce(([goodVals, badVals], val) => {
@@ -297,7 +297,11 @@ const validateValueInList = (value, listValues, canFix, isEndValue) => {
     const err = badValues.length ? 
       `${plural ? "Values" : "Value"} ${badValues.join(", ")} ${plural ? "are" : "is"} not in list of values` : null;
     // always remove bad values at tree validation as user can't unselect them (except AntDesign widget)
-    canFix = canFix || isEndValue;
+    if (removeInvalidMultiSelectValuesOnLoad !== undefined) {
+      canFix = removeInvalidMultiSelectValuesOnLoad;
+    } else {
+      canFix = canFix || isEndValue;
+    }
     return [err, canFix ? goodValues : value];
   } else {
     const vv = getItemInListValues(listValues, value);
@@ -331,7 +335,7 @@ const validateNormalValue = (leftField, field, value, valueSrc, valueType, async
     if (fieldSettings) {
       const listValues = asyncListValues || fieldSettings.listValues;
       if (listValues && !fieldSettings.allowCustomValues) {
-        return validateValueInList(value, listValues, canFix, isEndValue);
+        return validateValueInList(value, listValues, canFix, isEndValue, config.settings.removeInvalidMultiSelectValuesOnLoad);
       }
       if (fieldSettings.min != null && value < fieldSettings.min) {
         return [`Value ${value} < min ${fieldSettings.min}`, canFix ? fieldSettings.min : value];

--- a/modules/utils/validation.js
+++ b/modules/utils/validation.js
@@ -282,7 +282,7 @@ export const validateValue = (config, leftField, field, operator, value, valueTy
   return [validError, fixedValue];
 };
 
-const validateValueInList = (value, listValues, canFix) => {
+const validateValueInList = (value, listValues, canFix, isEndValue) => {
   const values = List.isList(value) ? value.toJS() : (value instanceof Array ? [...value] : undefined);
   if (values) {
     const [goodValues, badValues] = values.reduce(([goodVals, badVals], val) => {
@@ -296,8 +296,9 @@ const validateValueInList = (value, listValues, canFix) => {
     const plural = badValues.length > 1;
     const err = badValues.length ? 
       `${plural ? "Values" : "Value"} ${badValues.join(", ")} ${plural ? "are" : "is"} not in list of values` : null;
-    canFix = true; // always remove bad values as user can't unselect them (except AntDesign widget)
-    return [err, canFix ? goodValues : value, badValues];
+    // always remove bad values at tree validation as user can't unselect them (except AntDesign widget)
+    canFix = canFix || isEndValue;
+    return [err, canFix ? goodValues : value];
   } else {
     const vv = getItemInListValues(listValues, value);
     if (vv == undefined) {
@@ -330,7 +331,7 @@ const validateNormalValue = (leftField, field, value, valueSrc, valueType, async
     if (fieldSettings) {
       const listValues = asyncListValues || fieldSettings.listValues;
       if (listValues && !fieldSettings.allowCustomValues) {
-        return validateValueInList(value, listValues, canFix);
+        return validateValueInList(value, listValues, canFix, isEndValue);
       }
       if (fieldSettings.min != null && value < fieldSettings.min) {
         return [`Value ${value} < min ${fieldSettings.min}`, canFix ? fieldSettings.min : value];

--- a/tests/specs/ChangeQueryProps.test.js
+++ b/tests/specs/ChangeQueryProps.test.js
@@ -1,12 +1,12 @@
 import { BasicConfig } from "react-awesome-query-builder";
 import * as configs from "../support/configs";
 import * as inits from "../support/inits";
-import { with_qb, load_tree } from "../support/utils";
+import { with_qb, with_qb_ant, load_tree } from "../support/utils";
 
 
 describe("change props", () => {
-  it("change tree via props triggers onChange", () => {
-    with_qb(configs.simple_with_2_numbers, inits.with_num_and_num2, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
+  it("change tree via props triggers onChange", async () => {
+    await with_qb(configs.simple_with_2_numbers, inits.with_num_and_num2, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
       const {tree, errors} = load_tree(inits.with_number, configs.simple_with_2_numbers(BasicConfig), "JsonLogic");
       await qb.setProps({
         value: tree
@@ -16,8 +16,8 @@ describe("change props", () => {
     });
   });
 
-  it("change config via props triggers onChange", () => {
-    with_qb(configs.simple_with_2_numbers, inits.with_num_and_num2, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change config via props triggers onChange", async () => {
+    await with_qb(configs.simple_with_2_numbers, inits.with_num_and_num2, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       const config_without_num2 = configs.simple_with_number(BasicConfig);
       qb.setProps({
         ...config_without_num2,
@@ -27,8 +27,17 @@ describe("change props", () => {
     });
   });
 
-  describe("load tree with another config", () => {
-    with_qb(configs.simple_with_number, inits.with_num_and_num2, "JsonLogic", (qb, onChange, {expect_checks}) => {
+  it("change UI framework should not produce error", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_treeselect, "JsonLogic", async (qb, onChange) => {
+      const config_vanilla = configs.with_all_types(BasicConfig);
+      await qb.setProps({
+        ...config_vanilla,
+      });
+    });
+  });
+
+  describe("load tree with another config", async () => {
+    await with_qb(configs.simple_with_number, inits.with_num_and_num2, "JsonLogic", (qb, onChange, {expect_checks}) => {
       expect_checks({
         logic: inits.with_number
       });

--- a/tests/specs/DragAndDrop.test.js
+++ b/tests/specs/DragAndDrop.test.js
@@ -7,8 +7,8 @@ import { simulate_drag_n_drop } from "../support/dnd";
 
 describe("drag-n-drop", () => {
 
-  it("should move rule after second rule", () => {
-    with_qb(configs.simple_with_number, inits.with_group, "JsonLogic", (qb, onChange, {expect_queries}) => {
+  it("should move rule after second rule", async () => {
+    await with_qb(configs.simple_with_number, inits.with_group, "JsonLogic", (qb, onChange, {expect_queries}) => {
       const firstRule = qb.find(".rule").at(0);
       const secondRule = qb.find(".rule").at(1);
 
@@ -28,8 +28,8 @@ describe("drag-n-drop", () => {
     });
   });
 
-  it("should move group before rule", () => {
-    with_qb(configs.simple_with_number, inits.with_number_and_group, "JsonLogic", (qb, onChange, {expect_queries}) => {
+  it("should move group before rule", async () => {
+    await with_qb(configs.simple_with_number, inits.with_number_and_group, "JsonLogic", (qb, onChange, {expect_queries}) => {
       const firstRule = qb.find(".rule").at(0);
       const group = qb.find(".group--children .group").at(0);
 
@@ -49,9 +49,9 @@ describe("drag-n-drop", () => {
     });
   });
 
-  it("should move rule into group", () => {
-    const do_test = (config, value, checks) => {
-      with_qb(config, value, "JsonLogic", (qb, onChange, tasks) => {
+  it("should move rule into group", async () => {
+    const do_test = async (config, value, checks) => {
+      await with_qb(config, value, "JsonLogic", (qb, onChange, tasks) => {
         const secondRule = qb.find(".rule").at(1);
         const group = qb.find(".group--children .group").at(0);
         const groupHeader = group.find(".group--header").first();
@@ -69,25 +69,25 @@ describe("drag-n-drop", () => {
       });
     };
 
-    do_test(configs.simple_with_number, inits.with_numbers_and_group, (config, value, onChange, {expect_queries}) => {
+    await do_test(configs.simple_with_number, inits.with_numbers_and_group, (config, value, onChange, {expect_queries}) => {
       expect_queries([
         "(num == 1 || num == 2 || (num == 3 && num == 4))",
         "(num == 1 || (num == 2 && num == 3 && num == 4))"
       ]);
     });
     
-    do_test(configs.simple_with_number_without_regroup, inits.with_numbers_and_group, (_config, _value, onChange, _tasks) => {
+    await do_test(configs.simple_with_number_without_regroup, inits.with_numbers_and_group, (_config, _value, onChange, _tasks) => {
       assert.notCalled(onChange);
     });
     
-    do_test(configs.simple_with_number_max_nesting_1, inits.with_numbers_and_group, (_config, _value, onChange, _tasks) => {
+    await do_test(configs.simple_with_number_max_nesting_1, inits.with_numbers_and_group, (_config, _value, onChange, _tasks) => {
       assert.notCalled(onChange);
     });
   });
 
-  it("should move rule out of group", () => {
-    const do_test = (config, value, checks) => {
-      with_qb(config, value, "JsonLogic", (qb, onChange, tasks) => {
+  it("should move rule out of group", async () => {
+    const do_test = async (config, value, checks) => {
+      await with_qb(config, value, "JsonLogic", (qb, onChange, tasks) => {
         const firstRuleInGroup = qb.find(".rule").at(1);
         const group = qb.find(".group--children .group").at(0);
         const groupHeader = group.find(".group--header").first();
@@ -105,20 +105,20 @@ describe("drag-n-drop", () => {
       });
     };
 
-    do_test(configs.simple_with_number, inits.with_number_and_group_3, (config, value, onChange, {expect_queries}) => {
+    await do_test(configs.simple_with_number, inits.with_number_and_group_3, (config, value, onChange, {expect_queries}) => {
       expect_queries([
         "(num == 1 || (num == 2 && num == 3 && num == 4))",
         "(num == 1 || num == 2 || (num == 3 && num == 4))"
       ]);
     });
     
-    do_test(configs.simple_with_number_without_regroup, inits.with_number_and_group_3, (_config, _value, onChange, _tasks) => {
+    await do_test(configs.simple_with_number_without_regroup, inits.with_number_and_group_3, (_config, _value, onChange, _tasks) => {
       assert.notCalled(onChange);
     });
   });
 
-  it("should move group before group", () => {
-    with_qb(configs.simple_with_number_without_regroup, inits.with_groups, "JsonLogic", (qb, onChange, {expect_queries}) => {
+  it("should move group before group", async () => {
+    await with_qb(configs.simple_with_number_without_regroup, inits.with_groups, "JsonLogic", (qb, onChange, {expect_queries}) => {
       const firstGroup = qb.find(".group--children .group").at(0);
       const secondGroup = qb.find(".group--children .group").at(1);
       const firstGroupHeader = firstGroup.find(".group--header").first();

--- a/tests/specs/InteractionsAntd.test.js
+++ b/tests/specs/InteractionsAntd.test.js
@@ -5,8 +5,8 @@ import { with_qb_ant } from "../support/utils";
 
 describe("interactions on antd", () => {
 
-  it("set not", () => {
-    with_qb_ant(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("set not", async () => {
+    await with_qb_ant(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".group--conjunctions .ant-btn-group button")
         .at(0)
@@ -17,8 +17,8 @@ describe("interactions on antd", () => {
     });
   });
 
-  it("change conjunction from AND to OR", () => {
-    with_qb_ant(configs.simple_with_numbers_and_str, inits.with_2_numbers, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change conjunction from AND to OR", async () => {
+    await with_qb_ant(configs.simple_with_numbers_and_str, inits.with_2_numbers, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".group--conjunctions .ant-btn-group button")
         .at(2)
@@ -32,14 +32,14 @@ describe("interactions on antd", () => {
     });
   });
 
-  it("should render labels with showLabels=true", () => {
-    with_qb_ant([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render labels with showLabels=true", async () => {
+    await with_qb_ant([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });
 
-  it("should render admin mode with showLock=true", () => {
-    with_qb_ant([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render admin mode with showLock=true", async () => {
+    await with_qb_ant([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });

--- a/tests/specs/InteractionsMui.test.js
+++ b/tests/specs/InteractionsMui.test.js
@@ -26,14 +26,14 @@ describe("interactions on MUI", () => {
     });
   });
 
-  it("should render labels with showLabels=true", () => {
-    with_qb_material([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render labels with showLabels=true", async () => {
+    await with_qb_material([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });
 
-  it("should render admin mode with showLock=true", () => {
-    with_qb_material([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render admin mode with showLock=true", async () => {
+    await with_qb_material([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });

--- a/tests/specs/InteractionsVanilla.test.js
+++ b/tests/specs/InteractionsVanilla.test.js
@@ -6,8 +6,8 @@ import { with_qb } from "../support/utils";
 
 
 describe("interactions on vanilla", () => {
-  it("click on remove single rule will leave empty rule if canLeaveEmptyGroup=false", () => {
-    with_qb(configs.dont_leave_empty_group, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("click on remove single rule will leave empty rule if canLeaveEmptyGroup=false", async () => {
+    await with_qb(configs.dont_leave_empty_group, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule .rule--header button")
         .first()
@@ -22,8 +22,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("click on remove group will leave empty rule if canLeaveEmptyGroup=false", () => {
-    with_qb(configs.dont_leave_empty_group, inits.with_group, "JsonLogic", (qb, onChange) => {
+  it("click on remove group will leave empty rule if canLeaveEmptyGroup=false", async () => {
+    await with_qb(configs.dont_leave_empty_group, inits.with_group, "JsonLogic", (qb, onChange) => {
       qb
         .find(".group--children .group .group--header .group--actions button")
         .at(2)
@@ -38,8 +38,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("click on add rule will add new empty rule", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("click on add rule will add new empty rule", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".group--actions button")
         .first()
@@ -50,8 +50,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("click on add group will add new group with one empty rule if shouldCreateEmptyGroup=false", () => {
-    with_qb(configs.dont_leave_empty_group, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("click on add group will add new group with one empty rule if shouldCreateEmptyGroup=false", async () => {
+    await with_qb(configs.dont_leave_empty_group, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".group--actions button")
         .at(1)
@@ -64,15 +64,16 @@ describe("interactions on vanilla", () => {
       expect(child.properties.conjunction).to.equal("AND"); //default
       const subchildKeys = Object.keys(child.children1);
       const subchild = child.children1[subchildKeys[0]];
-      expect(subchild).to.eql({
+      expect(JSON.stringify(subchild)).to.eql(JSON.stringify({
         type: "rule", 
-        properties: {field: null, operator: null, value: [], valueSrc: []}
-      });
+        id: subchild.id,
+        properties: {field: null, operator: null, value: [], valueSrc: []},
+      }));
     });
   });
 
-  it("change field to of same type will same op & value", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("change field to of same type will same op & value", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule .rule--field select")
         .simulate("change", { target: { value: "num2" } });
@@ -86,8 +87,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change field to of another type will flush value and incompatible op", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("change field to of another type will flush value and incompatible op", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule .rule--field select")
         .simulate("change", { target: { value: "str2" } });
@@ -101,8 +102,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change field to of another type will flush value and leave compatible op", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
+  it("change field to of another type will flush value and leave compatible op", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule .rule--field select")
         .simulate("change", { target: { value: "str" } });
@@ -116,8 +117,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change field from group_ext to simple", () => {
-    with_qb(configs.with_group_array_cars, inits.with_group_array_cars, "JsonLogic", (qb, onChange) => {
+  it("change field from group_ext to simple", async () => {
+    await with_qb(configs.with_group_array_cars, inits.with_group_array_cars, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule_group_ext .group--field--count--rule .rule--field select")
         .simulate("change", { target: { value: "str" } });
@@ -131,8 +132,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change field from group_ext to simple with custom operator", () => {
-    with_qb(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator, "JsonLogic", (qb, onChange) => {
+  it("change field from group_ext to simple with custom operator", async () => {
+    await with_qb(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule_group_ext .group--field--count--rule .rule--field select")
         .simulate("change", { target: { value: "str" } });
@@ -146,8 +147,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change field from simple to group_ext", () => {
-    with_qb(configs.with_group_array_cars, inits.with_text, "JsonLogic", (qb, onChange) => {
+  it("change field from simple to group_ext", async () => {
+    await with_qb(configs.with_group_array_cars, inits.with_text, "JsonLogic", (qb, onChange) => {
       qb
         .find(".rule .rule--field select")
         .simulate("change", { target: { value: "cars" } });
@@ -162,8 +163,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("set not", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("set not", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find('.group--conjunctions input[type="checkbox"]')
         .simulate("change", { target: { checked: true } });
@@ -173,8 +174,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change conjunction from AND to OR", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_2_numbers, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change conjunction from AND to OR", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_2_numbers, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find('.group--conjunctions input[type="radio"][value="OR"]')
         .simulate("change", { target: { value: "OR" } });
@@ -187,8 +188,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change value source to another field of same type", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change value source to another field of same type", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--valuesrc select")
         .simulate("change", { target: { value: "field" } });
@@ -201,8 +202,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("change op from equal to not_equal", () => {
-    with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change op from equal to not_equal", async () => {
+    await with_qb(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--operator select")
         .simulate("change", { target: { value: "not_equal" } });
@@ -212,8 +213,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("remove group with 2 rules with confirm", () => {
-    with_qb(configs.with_settings_confirm, inits.with_number_and_group, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
+  it("remove group with 2 rules with confirm", async () => {
+    await with_qb(configs.with_settings_confirm, inits.with_number_and_group, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
       const renderConfirm = config.settings.renderConfirm;
       qb
         .find(".group--children .group .group--header .group--actions button")
@@ -224,8 +225,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("remove group with 1 rule with confirm", () => {
-    with_qb(configs.with_settings_confirm, inits.with_number_and_group_1, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
+  it("remove group with 1 rule with confirm", async () => {
+    await with_qb(configs.with_settings_confirm, inits.with_number_and_group_1, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
       const renderConfirm = config.settings.renderConfirm;
       qb
         .find(".group--children .group .group--header .group--actions button")
@@ -236,8 +237,8 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("remove rule with confirm", () => {
-    with_qb(configs.with_settings_confirm, inits.with_2_numbers, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
+  it("remove rule with confirm", async () => {
+    await with_qb(configs.with_settings_confirm, inits.with_2_numbers, "JsonLogic", (qb, onChange,  {expect_jlogic, config}) => {
       const renderConfirm = config.settings.renderConfirm;
       qb
         .find(".group--children .rule-container")
@@ -250,28 +251,28 @@ describe("interactions on vanilla", () => {
     });
   });
 
-  it("should not render not with showNot=false", () => {
-    with_qb(configs.with_settings_not_show_not, inits.with_numbers_and_group, "JsonLogic", (qb) => {
+  it("should not render not with showNot=false", async () => {
+    await with_qb(configs.with_settings_not_show_not, inits.with_numbers_and_group, "JsonLogic", (qb) => {
       expect(qb.find(".group--conjunctions input[type='checkbox']")).to.have.length(0);
     });
   });
 
-  it("should handle maxNumberOfRules=3", () => {
-    with_qb(configs.with_settings_max_number_of_rules_3, inits.with_number_and_group, "JsonLogic", (qb) => {
+  it("should handle maxNumberOfRules=3", async () => {
+    await with_qb(configs.with_settings_max_number_of_rules_3, inits.with_number_and_group, "JsonLogic", (qb) => {
       // if max exceeded --> (3) Add group | Add group, Delete group
       // else -->            (5) Add rule, Add group | Add rule, Add group, Delete group
       expect(qb.find(".group--actions button")).to.have.length(3);
     });
   });
 
-  it("should render labels with showLabels=true", () => {
-    with_qb([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render labels with showLabels=true", async () => {
+    await with_qb([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });
 
-  it("should render admin mode with showLock=true", () => {
-    with_qb([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
+  it("should render admin mode with showLock=true", async () => {
+    await with_qb([configs.with_different_groups, configs.with_settings_show_lock], inits.with_different_groups, "JsonLogic", (qb) => {
       //todo
     });
   });

--- a/tests/specs/QueryWithConj.test.js
+++ b/tests/specs/QueryWithConj.test.js
@@ -5,8 +5,8 @@ import { with_qb_skins, export_checks } from "../support/utils";
 
 describe("query with conjunction", () => {
   describe("import", () => {
-    it("should work with simple value of JsonLogic format", () => {
-      with_qb_skins(configs.with_number_and_string, inits.with_number_and_string, "JsonLogic", (qb) => {
+    it("should work with simple value of JsonLogic format", async () => {
+      await with_qb_skins(configs.with_number_and_string, inits.with_number_and_string, "JsonLogic", (qb) => {
         expect(qb.find(".query-builder")).to.have.length(1);
       });
     });

--- a/tests/specs/QueryWithFieldCompare.test.js
+++ b/tests/specs/QueryWithFieldCompare.test.js
@@ -6,8 +6,8 @@ import { with_qb_skins, export_checks } from "../support/utils";
 describe("query with field compare", () => {
 
   describe("import", () => {
-    it("should work with simple value of JsonLogic format", () => {
-      with_qb_skins(configs.simple_with_2_numbers, inits.with_number_field_compare, "JsonLogic", (qb) => {
+    it("should work with simple value of JsonLogic format", async () => {
+      await with_qb_skins(configs.simple_with_2_numbers, inits.with_number_field_compare, "JsonLogic", (qb) => {
         expect(qb.find(".query-builder")).to.have.length(1);
       });
     });

--- a/tests/specs/QueryWithFunc.test.js
+++ b/tests/specs/QueryWithFunc.test.js
@@ -35,14 +35,14 @@ describe("query with func", () => {
     });
   });
 
-  it("should render func with antd", () => {
-    with_qb_ant(configs.with_funcs, inits.with_func_tolower_from_field, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("should render func with antd", async () => {
+    await with_qb_ant(configs.with_funcs, inits.with_func_tolower_from_field, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       expect(qb.find("FuncWidget")).to.have.length(1);
     });
   });
 
-  it("set function for number", () => {
-    with_qb(configs.with_funcs, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("set function for number", async () => {
+    await with_qb(configs.with_funcs, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--valuesrc select")
         .simulate("change", { target: { value: "func" } });

--- a/tests/specs/QueryWithGroupsAndStructs.test.js
+++ b/tests/specs/QueryWithGroupsAndStructs.test.js
@@ -6,13 +6,13 @@ import { with_qb_skins, export_checks } from "../support/utils";
 describe("query with !struct and !group", () => {
 
   describe("import", () => {
-    it("should work with value of JsonLogic format", () => {
-      with_qb_skins(configs.with_struct_and_group, inits.with_struct_and_group, "JsonLogic", (qb) => {
+    it("should work with value of JsonLogic format", async () => {
+      await with_qb_skins(configs.with_struct_and_group, inits.with_struct_and_group, "JsonLogic", (qb) => {
         expect(qb.find(".query-builder")).to.have.length(1);
       });
     });
-    it("should handle custom operator in !group arrays", () => {
-      with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+    it("should handle custom operator in !group arrays", async () => {
+      await with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
         expect_checks({
           "logic": {
             "and": [

--- a/tests/specs/QueryWithProximity.test.js
+++ b/tests/specs/QueryWithProximity.test.js
@@ -13,8 +13,8 @@ describe("proximity", () => {
     });
   });
 
-  it("change NEAR", () => {
-    with_qb(configs.with_prox, inits.with_prox, "default", (qb, onChange, {expect_queries}) => {
+  it("change NEAR", async () => {
+    await with_qb(configs.with_prox, inits.with_prox, "default", (qb, onChange, {expect_queries}) => {
       qb
         .find(".rule .rule--operator-options .rule--operator .operator--options select")
         .simulate("change", { target: { value: "5" } });

--- a/tests/specs/QueryWithSubquery.test.js
+++ b/tests/specs/QueryWithSubquery.test.js
@@ -6,8 +6,8 @@ import { with_qb_skins, export_checks } from "../support/utils";
 describe("query with subquery and datetime types", () => {
 
   describe("import", () => {
-    it("should work with simple value of JsonLogic format", () => {
-      with_qb_skins(configs.with_date_and_time, inits.with_date_and_time, "JsonLogic", (qb) => {
+    it("should work with simple value of JsonLogic format", async () => {
+      await with_qb_skins(configs.with_date_and_time, inits.with_date_and_time, "JsonLogic", (qb) => {
         expect(qb.find(".query-builder")).to.have.length(1);
       });
     });
@@ -52,8 +52,8 @@ describe("query with subquery and datetime types", () => {
 describe("query with subquery and select types", () => {
 
   describe("import", () => {
-    it("should work with value of JsonLogic format", () => {
-      with_qb_skins(configs.with_select, inits.with_select_and_multiselect, "JsonLogic", (qb) => {
+    it("should work with value of JsonLogic format", async () => {
+      await with_qb_skins(configs.with_select, inits.with_select_and_multiselect, "JsonLogic", (qb) => {
         expect(qb.find(".query-builder")).to.have.length(1);
       });
     });

--- a/tests/specs/RareFeatures.test.js
+++ b/tests/specs/RareFeatures.test.js
@@ -7,7 +7,7 @@ import { with_qb, empty_value, export_checks } from "../support/utils";
 
 
 describe("rare features", () => {
-  it("export uses fieldName", () => {
+  describe("export uses fieldName", () => {
     export_checks(configs.with_fieldName, inits.with_number, "JsonLogic", {
       "query": "state.input.num == 2",
       "queryHuman": "Number = 2",
@@ -30,7 +30,7 @@ describe("rare features", () => {
     });
   });
 
-  it("import uses fieldName", () => {
+  describe("import uses fieldName", () => {
     export_checks(configs.with_fieldName, inits.with_fieldName, "JsonLogic", {
       "query": "state.input.num == 2",
       "queryHuman": "Number = 2",
@@ -53,7 +53,7 @@ describe("rare features", () => {
     });
   });
 
-  it("uses groupVarKey and altVarKey", () => {
+  describe("uses groupVarKey and altVarKey", () => {
     export_checks(configs.with_groupVarKey, inits.with_groupVarKey, "JsonLogic", {
       "query": "(stock == true && results.score > 8)",
       "queryHuman": "(In stock AND Results.score > 8)",

--- a/tests/specs/Validation.test.js
+++ b/tests/specs/Validation.test.js
@@ -6,8 +6,8 @@ import { with_qb } from "../support/utils";
 
 
 describe("validation", () => {
-  it("shows error when change number value to > max", () => {
-    with_qb(configs.with_all_types__show_error, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("shows error when change number value to > max", async () => {
+    await with_qb(configs.with_all_types__show_error, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input")
         .simulate("change", { target: { value: "200" } });

--- a/tests/specs/WidgetsAntd.test.js
+++ b/tests/specs/WidgetsAntd.test.js
@@ -6,30 +6,30 @@ import { with_qb_ant } from "../support/utils";
 
 describe("antdesign widgets render", () => {
 
-  it("should render select by default", () => {
-    with_qb_ant(configs.with_struct, inits.with_nested, "JsonLogic", (qb) => {
+  it("should render select by default", async () => {
+    await with_qb_ant(configs.with_struct, inits.with_nested, "JsonLogic", (qb) => {
       expect(qb.find(".query-builder")).to.have.length(1);
       expect(qb.find(".ant-select-selection-item").at(0).text()).to.equal("  firstName");
     });
   });
 
-  it("should render cascader", () => {
-    with_qb_ant(configs.with_cascader, inits.with_nested, "JsonLogic", (qb) => {
+  it("should render cascader", async () => {
+    await with_qb_ant(configs.with_cascader, inits.with_nested, "JsonLogic", (qb) => {
       expect(qb.find(".query-builder")).to.have.length(1);
       expect(qb.find(".ant-cascader .ant-select-selector").text()).to.equal("User / info / firstName");
     });
   });
 
-  it("should render tree select", () => {
-    with_qb_ant(configs.with_tree_select, inits.with_nested, "JsonLogic", (qb) => {
+  it("should render tree select", async () => {
+    await with_qb_ant(configs.with_tree_select, inits.with_nested, "JsonLogic", (qb) => {
       expect(qb.find(".query-builder")).to.have.length(1);
       expect(qb.find(".ant-select.ant-tree-select")).to.have.length(1);
       expect(qb.find(".ant-select-selection-item").at(0).text()).to.equal("firstName");
     });
   });
 
-  it("should render tree dropdown", () => {
-    with_qb_ant(configs.with_dropdown, inits.with_nested, "JsonLogic", (qb) => {
+  it("should render tree dropdown", async () => {
+    await with_qb_ant(configs.with_dropdown, inits.with_nested, "JsonLogic", (qb) => {
       expect(qb.find(".query-builder")).to.have.length(1);
       expect(qb.find(".ant-dropdown-trigger span").at(0).text().trim()).to.equal("firstName");
     });
@@ -40,8 +40,8 @@ describe("antdesign widgets render", () => {
 //////////////////////////////////////////////////////////////////////////////////////////
 
 describe("antdesign widgets interactions", () => {
-  it("change date value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_date, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change date value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_date, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find("DateWidget")
         .instance()
@@ -52,8 +52,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change select value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_select, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change select value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_select, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       const w = qb.find("SelectWidget").instance();
 
       w.handleChange("green");
@@ -67,8 +67,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change multiselect value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_multiselect, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change multiselect value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_multiselect, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       const w = qb.find("MultiSelectWidget").instance();
       
       w.handleChange(["orange"]);
@@ -92,8 +92,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change treeselect value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_treeselect, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+  it("change treeselect value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_treeselect, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
       expect_checks({
         "query": "selecttree == \"2\"",
         "queryHuman": "Color (tree) = Red",
@@ -118,8 +118,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change multitreeselect value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_multiselecttree, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+  it("change multitreeselect value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_multiselecttree, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
       expect_checks({
         "query": "multiselecttree == [\"2\", \"5\"]",
         "queryHuman": "Colors (tree) = [Red, Green]",
@@ -158,8 +158,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change time value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_time, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change time value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_time, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find("TimeWidget")
         .instance()
@@ -170,8 +170,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change datetime value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_datetime, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change datetime value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_datetime, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find("DateTimeWidget")
         .instance()
@@ -182,8 +182,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change slider value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_slider, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change slider value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_slider, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       const w = qb.find("SliderWidget").instance();
 
       w.handleChange(12);
@@ -196,8 +196,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change bool value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_bool, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change bool value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_bool, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find("BooleanWidget")
         .instance()
@@ -208,8 +208,8 @@ describe("antdesign widgets interactions", () => {
     });
   });
 
-  it("change range slider value", () => {
-    with_qb_ant(configs.with_all_types, inits.with_range_slider, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+  it("change range slider value", async () => {
+    await with_qb_ant(configs.with_all_types, inits.with_range_slider, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
       expect_checks({
         "query": "slider >= 18 && slider <= 42",
         "queryHuman": "Slider BETWEEN 18 AND 42",
@@ -255,8 +255,8 @@ describe("antdesign widgets interactions", () => {
   
   describe("antdesign widgets", () => {
 
-    it("load date range", () => {
-      with_qb_ant(configs.with_all_types, inits.with_range_dates, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+    it("load date range", async () => {
+      await with_qb_ant(configs.with_all_types, inits.with_range_dates, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
         expect_checks({
           "query": "date >= \"2020-05-10\" && date <= \"2020-05-15\"",
           "queryHuman": "Date BETWEEN 10.05.2020 AND 15.05.2020",
@@ -271,8 +271,8 @@ describe("antdesign widgets interactions", () => {
       });
     });
   
-    it("load bad date range", () => {
-      with_qb_ant(configs.with_all_types, inits.with_range_bad_dates, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
+    it("load bad date range", async () => {
+      await with_qb_ant(configs.with_all_types, inits.with_range_bad_dates, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
         expect_checks({});
       });
     });
@@ -283,8 +283,8 @@ describe("antdesign widgets interactions", () => {
 
   describe("antdesign core widgets", () => {
 
-    it("change field via cascader", () => {
-      with_qb_ant(configs.with_cascader, inits.with_nested, "JsonLogic", (qb) => {
+    it("change field via cascader", async () => {
+      await with_qb_ant(configs.with_cascader, inits.with_nested, "JsonLogic", (qb) => {
         const w = qb.find("FieldCascader").instance();
 
         w.onChange(["user", "login"]);
@@ -295,8 +295,8 @@ describe("antdesign widgets interactions", () => {
       });
     });
 
-    it("change field via select", () => {
-      with_qb_ant(configs.with_struct, inits.with_nested, "JsonLogic", (qb) => {
+    it("change field via select", async () => {
+      await with_qb_ant(configs.with_struct, inits.with_nested, "JsonLogic", (qb) => {
         const w = qb.find("FieldSelect").first().instance();
 
         w.onChange("user.login");
@@ -307,16 +307,16 @@ describe("antdesign widgets interactions", () => {
       });
     });
 
-    it("change field via dropdown", () => {
-      with_qb_ant(configs.with_dropdown, inits.with_nested, "JsonLogic", (qb) => {
+    it("change field via dropdown", async () => {
+      await with_qb_ant(configs.with_dropdown, inits.with_nested, "JsonLogic", (qb) => {
         const w = qb.find("FieldDropdown").first().instance();
 
         w.onChange({key: "user.login"});
       });
     });
 
-    it("change field via tree select", () => {
-      with_qb_ant(configs.with_tree_select, inits.with_nested, "JsonLogic", (qb) => {
+    it("change field via tree select", async () => {
+      await with_qb_ant(configs.with_tree_select, inits.with_nested, "JsonLogic", (qb) => {
         const w = qb.find("FieldTreeSelect").first().instance();
 
         w.onChange("user.login");

--- a/tests/specs/WidgetsVanilla.test.js
+++ b/tests/specs/WidgetsVanilla.test.js
@@ -4,8 +4,8 @@ import { with_qb, with_qb_skins } from "../support/utils";
 
 
 describe("vanilla widgets interactions", () => {
-  it("change number value", () => {
-    with_qb_skins(configs.with_all_types, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change number value", async () => {
+    await with_qb_skins(configs.with_all_types, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input")
         .simulate("change", { target: { value: "3" } });
@@ -15,8 +15,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change text value", () => {
-    with_qb_skins(configs.with_all_types, inits.with_text, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change text value", async () => {
+    await with_qb_skins(configs.with_all_types, inits.with_text, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input")
         .simulate("change", { target: { value: "def" } });
@@ -26,8 +26,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change date value", () => {
-    with_qb(configs.with_all_types, inits.with_date, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change date value", async () => {
+    await with_qb(configs.with_all_types, inits.with_date, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input")
         .simulate("change", { target: { value: "2020-05-05" } });
@@ -37,8 +37,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change datetime value", () => {
-    with_qb(configs.with_all_types, inits.with_datetime, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change datetime value", async () => {
+    await with_qb(configs.with_all_types, inits.with_datetime, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input")
         .simulate("change", { target: { value: "2020-05-05T02:30" } });
@@ -48,8 +48,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change select value", () => {
-    with_qb(configs.with_all_types, inits.with_select, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change select value", async () => {
+    await with_qb(configs.with_all_types, inits.with_select, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget select")
         .simulate("change", { target: { value: "green" } });
@@ -59,8 +59,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change multiselect value", () => {
-    with_qb(configs.with_all_types, inits.with_multiselect, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change multiselect value", async () => {
+    await with_qb(configs.with_all_types, inits.with_multiselect, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget select")
         .simulate("change", { target: { options: [ {value: "yellow", selected: true}, {value: "green"}, {value: "orange"} ] } });
@@ -77,8 +77,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change bool value", () => {
-    with_qb(configs.with_all_types, inits.with_bool, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change bool value", async () => {
+    await with_qb(configs.with_all_types, inits.with_bool, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input[value=false]")
         .simulate("change", { target: { value: "false" } });
@@ -88,8 +88,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change slider value", () => {
-    with_qb(configs.with_all_types, inits.with_slider, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change slider value", async () => {
+    await with_qb(configs.with_all_types, inits.with_slider, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input[type='range']")
         .simulate("change", { target: { value: 42 } });
@@ -99,8 +99,8 @@ describe("vanilla widgets interactions", () => {
     });
   });
 
-  it("change time value", () => {
-    with_qb(configs.with_all_types, inits.with_time, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
+  it("change time value", async () => {
+    await with_qb(configs.with_all_types, inits.with_time, "JsonLogic", (qb, onChange, {expect_jlogic}) => {
       qb
         .find(".rule .rule--value .widget--widget input[type='time']")
         .simulate("change", { target: { value: "10:30" } });

--- a/tests/support/inits.js
+++ b/tests/support/inits.js
@@ -474,7 +474,7 @@ export const with_datetime = {
 };
 
 export const with_select = {
-  "and": [{  "==": [ { "var": "color" }, "red" ]  }]
+  "and": [{  "==": [ { "var": "color" }, "orange" ]  }]
 };
 
 export const with_bool = {

--- a/tests/support/utils.tsx
+++ b/tests/support/utils.tsx
@@ -12,7 +12,7 @@ import {
 const {
   uuid, 
   checkTree, loadTree, _loadFromJsonLogic, loadFromSpel, isJsonLogic, elasticSearchFormat,
-  queryString, sqlFormat, spelFormat, mongodbFormat, jsonLogicFormat, queryBuilderFormat, getTree,
+  queryString, sqlFormat, spelFormat, mongodbFormat, jsonLogicFormat, queryBuilderFormat, getTree, ConfigUtils
 } = Utils;
 import AntdConfig from "react-awesome-query-builder/config/antd";
 import MaterialConfig from "react-awesome-query-builder/config/material";
@@ -98,6 +98,8 @@ export  const with_qb_skins = async (config_fn: ConfigFns, value: TreeValue, val
 const do_with_qb = async (BasicConfig: Config, config_fn: ConfigFns, value: TreeValue, valueFormat: TreeValueFormat, checks: ChecksFn, options?: DoOptions) => {
   const config_fns = (Array.isArray(config_fn) ? config_fn : [config_fn]) as [ConfigFn];
   const config = config_fns.reduce((c, f) => f(c), BasicConfig);
+  // normally config should be saved at state in `onChange`, see README
+  const extendedConfig = ConfigUtils.extendConfig(config);
   const onChange = spy();
   const {tree, errors} = load_tree(value, config, valueFormat);
   if (errors?.length) {
@@ -112,7 +114,7 @@ const do_with_qb = async (BasicConfig: Config, config_fn: ConfigFns, value: Tree
       expect_queries_before_and_after(config, tree as ImmutableTree, onChange, queries);
     },
     expect_checks: (expects) => {
-      do_export_checks(config, tree as ImmutableTree, expects, false, true);
+      do_export_checks(extendedConfig, tree as ImmutableTree, expects, false, true);
     },
     config: config,
   };


### PR DESCRIPTION
  - Handle validation of bad multiselect value correctly:
    Remove bad values from list, don't unset whole value.
 - Added config `removeInvalidMultiSelectValuesOnLoad` (true by default, false for AntDesign)

Fixes #674