### PR TITLE
fix: not operation at the root not detected when importing from spel expression

### DIFF
--- a/modules/import/spel.js
+++ b/modules/import/spel.js
@@ -36,7 +36,7 @@ export const _loadFromSpel = (spelStr, config, returnErrors = true) => {
 
     jsTree = convertToTree(convertedObj, conv, extendedConfig, meta);
     if (jsTree && jsTree.type != "group" && jsTree.type != "switch_group") {
-      jsTree = wrapInDefaultConj(jsTree, extendedConfig);
+      jsTree = wrapInDefaultConj(jsTree, extendedConfig, convertedObj["not"]);
     }
     logger.debug("jsTree:", jsTree);
   }
@@ -864,7 +864,7 @@ const wrapInDefaultConj = (rule, config, not = false) => {
     children1: { [rule.id]: rule },
     properties: {
       conjunction: defaultConjunction(config),
-      not: not
+      not: not || false
     }
   };
 };


### PR DESCRIPTION
Fix #766 

cc: @ukrbublik 