### PR TITLE
fix: Add typings for groupOperators

### DIFF
--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -870,6 +870,7 @@ export interface BehaviourSettings {
   removeEmptyGroupsOnLoad?: boolean,
   removeIncompleteRulesOnLoad?: boolean,
   removeInvalidMultiSelectValuesOnLoad?: boolean,
+  groupOperators?: Array<string>,
 }
 
 export interface OtherSettings {


### PR DESCRIPTION
Typings for [groupOperators](https://github.com/ukrbublik/react-awesome-query-builder/blame/master/CONFIG.adoc#L311) were missing causing it to show errors on TS compiler.