### PR TITLE
Fix Bug

### DIFF
--- a/modules/components/widgets/mui/index.js
+++ b/modules/components/widgets/mui/index.js
@@ -45,12 +45,11 @@ const MuiProvider = ({config, children}) => {
       },
     }
   });
-
-  const base = (<div className="mui">{children}</div>);
+  
   const withProviders = (
     <LocalizationProvider dateAdapter={AdapterMoment} >
       <ConfirmProvider>
-        {base}
+       <div className="mui">{children}</div>
       </ConfirmProvider>
     </LocalizationProvider>
   );


### PR DESCRIPTION
./node_modules/react-awesome-query-builder/modules/components/widgets/mui/index.js SyntaxError: C:\...\Frontend\node_modules\react-awesome-query-builder\modules\components\widgets\mui\index.js: Support for the experimental syntax 'jsx' isn't currently enabled (49:17):

  47 |   });
  48 |
> 49 |   const base = (<div className="mui">{children}</div>);
     |                 ^
  50 |   const withProviders = (
  51 |     <LocalizationProvider dateAdapter={AdapterMoment} >
  52 |       <ConfirmProvider>

Add @babel/preset-react (https://git.io/JfeDR) to the 'presets' section of your Babel config to enable transformation. If you want to leave it as-is, add @babel/plugin-syntax-jsx (https://git.io/vb4yA) to the 'plugins' section to enable parsing.