### PR TITLE
Add `multiselect_contains` operator

### DIFF
--- a/CONFIG.adoc
+++ b/CONFIG.adoc
@@ -94,6 +94,7 @@ const {
         select_not_equals,
         select_any_in,
         select_not_any_in,
+        multiselect_contains,
         multiselect_equals, // like `equal`, but for multiselect
         multiselect_not_equals,
         proximity, // complex operator with options

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -466,7 +466,14 @@ const operators = {
     mongoFormatOp: mongoFormatOp1.bind(null, "$nin", v => v, false),
     reversedOp: "select_any_in",
   },
-  //todo: multiselect_contains - for SpEL it would be `.containsAll`
+  multiselect_contains: {
+    label: "Contains",
+    jsonLogic2: "some-in",
+    jsonLogic: (field, op, vals) => ({
+      // it's not "equals", but "includes" operator - just for example
+      "some": [ field, {"in": [{"var": ""}, vals]} ]
+    }),
+  },
   multiselect_equals: {
     label: "Equals",
     labelForFormat: "==",
@@ -1111,6 +1118,7 @@ const types = {
     widgets: {
       multiselect: {
         operators: [
+          "multiselect_contains",
           "multiselect_equals",
           "multiselect_not_equals",
           // "is_empty",

--- a/modules/config/basic.js
+++ b/modules/config/basic.js
@@ -470,7 +470,6 @@ const operators = {
     label: "Contains",
     jsonLogic2: "some-in",
     jsonLogic: (field, op, vals) => ({
-      // it's not "equals", but "includes" operator - just for example
       "some": [ field, {"in": [{"var": ""}, vals]} ]
     }),
   },

--- a/modules/import/jsonLogic.js
+++ b/modules/import/jsonLogic.js
@@ -456,9 +456,9 @@ const parseRule = (op, arity, vals, parentField, conv, config, meta) => {
 
 const _parseRule = (op, arity, vals, parentField, conv, config, errors, isRevArgs) => {
   // config.settings.groupOperators are used for group count (cardinality = 0 is exception)
-  // but don't confuse with "all-in" for multiselect
-  const isAllInForMultiselect = op == "all" && isJsonLogic(vals[1]) && Object.keys(vals[1])[0] == "in";
-  const isGroup0 = !isAllInForMultiselect && config.settings.groupOperators.includes(op);
+  // but don't confuse with "all-in" or "some-in" for multiselect
+  const isAllOrSomeInForMultiselect = (op == "all" || op == "some") && isJsonLogic(vals[1]) && Object.keys(vals[1])[0] == "in";
+  const isGroup0 = !isAllOrSomeInForMultiselect && config.settings.groupOperators.includes(op);
   const eqOps = ["==", "!="];
   let cardinality = isGroup0 ? 0 : arity - 1;
   if (isGroup0)
@@ -559,15 +559,15 @@ const convertOp = (op, vals, conv, config, not, meta, parentField = null) => {
   if (!op) return undefined;
 
   const arity = vals.length;
-  if (op == "all" && isJsonLogic(vals[1])) {
-    // special case for "all-in"
+  if (op == "all" || op == "some" && isJsonLogic(vals[1])) {
+    // special case for "all-in" and "some-in"
     const op2 = Object.keys(vals[1])[0];
     if (op2 == "in") {
       vals = [
         vals[0],
         vals[1][op2][1]
       ];
-      op = op + "-" + op2; // "all-in"
+      op = op + "-" + op2; // "all-in" and "some-in"
     }
   }
 

--- a/modules/index.d.ts
+++ b/modules/index.d.ts
@@ -962,6 +962,7 @@ export interface BasicConfig extends Config {
     select_not_equals: BinaryOperator,
     select_any_in: BinaryOperator,
     select_not_any_in: BinaryOperator,
+    multiselect_contains: BinaryOperator,
     multiselect_equals: BinaryOperator,
     multiselect_not_equals: BinaryOperator,
     proximity: OperatorProximity,


### PR DESCRIPTION
Adds a new operator called `multiselect_contains` that uses the `some` array operator.

JsonLogic for `multiselect_contains` looks like:
```
{
  "some": [
    {
      "var": "fruits"
    },
    {
      "in": [
        {
          "var": ""
        },
        [
          "apple",
          "orange",
          "banana"
        ]
      ]
    }
  ]
}
```

An example of where this is helpful is [issue #270](https://github.com/ukrbublik/react-awesome-query-builder/issues/270).

I have implemented the operator logic for JsonLogic as I'm unfamiliar with the other support query languages.