### PR TITLE
Fix import of is_null and is_not_null ops from SpEL

### DIFF
--- a/packages/core/modules/import/spel.js
+++ b/packages/core/modules/import/spel.js
@@ -492,15 +492,6 @@ const buildRule = (config, meta, field, opKey, convertedArgs) => {
   const asyncListValuesArr = convertedArgs.map(v => v.asyncListValues).filter(v => v != undefined);
   const asyncListValues = asyncListValuesArr.length ? asyncListValuesArr[0] : undefined;
 
-  const value = convertedArgs.map(function (v) {return v.value;});
-
-  if (opKey === "equal" && value && value[0] === null) {
-    opKey = "is_null";
-  }
-  if (opKey === "not_equal" && value && value[0] === null) {
-    opKey = "is_not_null";
-  }
-
   let res = {
     type: "rule",
     id: uuid(),
@@ -700,6 +691,14 @@ const convertToTree = (spel, conv, config, meta, parentSpel = null) => {
             opKey = ws.op;
           }
         }
+
+        const opArg = convertedArgs[0];
+        if (opKey === "equal" && opArg.value === null) {
+          opKey = "is_null";
+        } else if (opKey === "not_equal" && opArg.value === null) {
+          opKey = "is_not_null";
+        }
+
         res = buildRule(config, meta, field, opKey, convertedArgs);
       }
     } else {

--- a/packages/core/modules/import/spel.js
+++ b/packages/core/modules/import/spel.js
@@ -491,6 +491,16 @@ const buildRule = (config, meta, field, opKey, convertedArgs) => {
   const widgetConfig = config.widgets[widget || fieldConfig.mainWidget];
   const asyncListValuesArr = convertedArgs.map(v => v.asyncListValues).filter(v => v != undefined);
   const asyncListValues = asyncListValuesArr.length ? asyncListValuesArr[0] : undefined;
+
+  const value = convertedArgs.map(function (v) {return v.value});
+
+  if (opKey === 'equal' && value && value[0] === null) {
+    opKey = 'is_null';
+  }
+  if (opKey === 'not_equal' && value && value[0] === null) {
+    opKey = 'is_not_null';
+  }
+  
   let res = {
     type: "rule",
     id: uuid(),

--- a/packages/core/modules/import/spel.js
+++ b/packages/core/modules/import/spel.js
@@ -491,7 +491,6 @@ const buildRule = (config, meta, field, opKey, convertedArgs) => {
   const widgetConfig = config.widgets[widget || fieldConfig.mainWidget];
   const asyncListValuesArr = convertedArgs.map(v => v.asyncListValues).filter(v => v != undefined);
   const asyncListValues = asyncListValuesArr.length ? asyncListValuesArr[0] : undefined;
-
   let res = {
     type: "rule",
     id: uuid(),
@@ -693,9 +692,9 @@ const convertToTree = (spel, conv, config, meta, parentSpel = null) => {
         }
 
         const opArg = convertedArgs[0];
-        if (opKey === "equal" && opArg.value === null) {
+        if (opKey === "equal" && opArg?.value === null) {
           opKey = "is_null";
-        } else if (opKey === "not_equal" && opArg.value === null) {
+        } else if (opKey === "not_equal" && opArg?.value === null) {
           opKey = "is_not_null";
         }
 

--- a/packages/core/modules/import/spel.js
+++ b/packages/core/modules/import/spel.js
@@ -492,15 +492,15 @@ const buildRule = (config, meta, field, opKey, convertedArgs) => {
   const asyncListValuesArr = convertedArgs.map(v => v.asyncListValues).filter(v => v != undefined);
   const asyncListValues = asyncListValuesArr.length ? asyncListValuesArr[0] : undefined;
 
-  const value = convertedArgs.map(function (v) {return v.value});
+  const value = convertedArgs.map(function (v) {return v.value;});
 
-  if (opKey === 'equal' && value && value[0] === null) {
-    opKey = 'is_null';
+  if (opKey === "equal" && value && value[0] === null) {
+    opKey = "is_null";
   }
-  if (opKey === 'not_equal' && value && value[0] === null) {
-    opKey = 'is_not_null';
+  if (opKey === "not_equal" && value && value[0] === null) {
+    opKey = "is_not_null";
   }
-  
+
   let res = {
     type: "rule",
     id: uuid(),


### PR DESCRIPTION
Fixed cannot import "is null" and "is not null" operators from spel import.