### PR TITLE
Add support for ElasticSearch 7 term syntax

### DIFF
--- a/packages/core/modules/export/elasticSearch.js
+++ b/packages/core/modules/export/elasticSearch.js
@@ -170,7 +170,7 @@ function determineField(fieldName, config) {
   return fieldName;
 }
 
-function buildParameters(queryType, value, operator, fieldName, config) {
+function buildParameters(queryType, value, operator, fieldName, config, syntax) {
   const textField = determineField(fieldName, config);
   switch (queryType) {
   case "filter":
@@ -186,7 +186,10 @@ function buildParameters(queryType, value, operator, fieldName, config) {
     return { [textField]: value[0] };
 
   case "term":
-    return { [fieldName]: value[0] };
+    return syntax === ES_7_SYNTAX
+      ? { [fieldName]: {
+        value: value[0]
+      }} : { [fieldName]: value[0] };
 
   //todo: not used
   // need to add geo type into RAQB or remove this code
@@ -213,10 +216,11 @@ function buildParameters(queryType, value, operator, fieldName, config) {
  * @param {string} fieldDataType - The type of data this field holds
  * @param {string} value - The value of this rule
  * @param {string} operator - The condition on how the value is matched
+ * @param {string} syntax - The version of ElasticSearch syntax to generate
  * @returns {object} - The ES rule
  * @private
  */
-function buildEsRule(fieldName, value, operator, config, valueSrc) {
+function buildEsRule(fieldName, value, operator, config, valueSrc, syntax) {
   if (!fieldName || !operator || value == undefined)
     return undefined; // rule is not fully entered
   let op = operator;
@@ -261,7 +265,7 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
   if (typeof elasticSearchFormatValue === "function") {
     parameters = elasticSearchFormatValue(queryType, value, op, fieldName, config);
   } else {
-    parameters = buildParameters(queryType, value, op, fieldName, config);
+    parameters = buildParameters(queryType, value, op, fieldName, config, syntax);
   }
 
   if (not) {
@@ -289,12 +293,12 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
  * @private
  * @returns {object} - The ES group
  */
-function buildEsGroup(children, conjunction, not, recursiveFxn, config) {
+function buildEsGroup(children, conjunction, not, recursiveFxn, config, syntax) {
   if (!children || !children.size)
     return undefined;
   const childrenArray = children.valueSeq().toArray();
   const occurrence = determineOccurrence(conjunction, not);
-  const result = childrenArray.map((c) => recursiveFxn(c, config)).filter(v => v !== undefined);
+  const result = childrenArray.map((c) => recursiveFxn(c, config, syntax)).filter(v => v !== undefined);
   if (!result.length)
     return undefined;
   const resultFlat = result.flat(Infinity);
@@ -305,7 +309,10 @@ function buildEsGroup(children, conjunction, not, recursiveFxn, config) {
   };
 }
 
-export function elasticSearchFormat(tree, config) {
+export const ES_7_SYNTAX = "ES_7_SYNTAX";
+export const ES_6_SYNTAX = "ES_6_SYNTAX";
+
+export function elasticSearchFormat(tree, config, syntax = ES_6_SYNTAX) {
   // -- format the es dsl here
   if (!tree) return undefined;
   const type = tree.get("type");
@@ -326,11 +333,11 @@ export function elasticSearchFormat(tree, config) {
 
     if (value && Array.isArray(value[0])) {
       //TODO : Handle case where the value has multiple values such as in the case of a list
-      return value[0].map((val) => 
-        buildEsRule(field, [val], operator, config, valueSrc)
+      return value[0].map((val) =>
+        buildEsRule(field, [val], operator, config, valueSrc, syntax)
       );
     } else {
-      return buildEsRule(field, value, operator, config, valueSrc);
+      return buildEsRule(field, value, operator, config, valueSrc, syntax);
     }
   }
 
@@ -340,6 +347,6 @@ export function elasticSearchFormat(tree, config) {
     if (!conjunction)
       conjunction = defaultConjunction(config);
     const children = tree.get("children1");
-    return buildEsGroup(children, conjunction, not, elasticSearchFormat, config);
+    return buildEsGroup(children, conjunction, not, elasticSearchFormat, config, syntax);
   }
 }

--- a/packages/core/modules/index.d.ts
+++ b/packages/core/modules/index.d.ts
@@ -172,7 +172,7 @@ export interface Utils {
   _spelFormat(tree: ImmutableTree, config: Config): [string | undefined, Array<string>];
   mongodbFormat(tree: ImmutableTree, config: Config): Object | undefined;
   _mongodbFormat(tree: ImmutableTree, config: Config): [Object | undefined, Array<string>];
-  elasticSearchFormat(tree: ImmutableTree, config: Config): Object | undefined;
+  elasticSearchFormat(tree: ImmutableTree, config: Config, syntax?: "ES_6_SYNTAX" | "ES_7_SYNTAX"): Object | undefined;
   // load, save
   getTree(tree: ImmutableTree, light?: boolean, children1AsArray?: boolean): JsonTree;
   loadTree(jsonTree: JsonTree): ImmutableTree;

--- a/packages/tests/specs/QueryWithConj.test.js
+++ b/packages/tests/specs/QueryWithConj.test.js
@@ -47,7 +47,27 @@ describe("query with conjunction", () => {
                 "login": "ukrbublik"
               }
             }
-          ] 
+          ]
+        }
+      },
+      elasticSearch7: {
+        "bool": {
+          "should": [
+            {
+              "range": {
+                "num": {
+                  "lt": "2"
+                }
+              }
+            },
+            {
+              "term": {
+                "login": {
+                  "value": "ukrbublik"
+                }
+              }
+            }
+          ]
         }
       },
     });

--- a/packages/tests/support/utils.tsx
+++ b/packages/tests/support/utils.tsx
@@ -41,6 +41,7 @@ interface ExtectedExports {
   spel?: string;
   mongo?: Object;
   elasticSearch?: Object;
+  elasticSearch7?: Object;
   logic?: JsonLogicTree;
 }
 interface Tasks {
@@ -266,7 +267,14 @@ const do_export_checks = (config: Config, tree: ImmutableTree, expects: Extected
         expect(JSON.stringify(res)).to.eql(JSON.stringify(expects["elasticSearch"]));
       });
     }
-  
+
+    if (expects["elasticSearch7"] !== undefined) {
+      doIt("should work with elasticSearch", () => {
+        const res = elasticSearchFormat(tree, config, "ES_7_SYNTAX");
+        expect(JSON.stringify(res)).to.eql(JSON.stringify(expects["elasticSearch7"]));
+      });
+    }
+
     if (expects["logic"] !== undefined) {
       doIt("should work to JsonLogic", () => {
         const {logic, data, errors} = jsonLogicFormat(tree, config);


### PR DESCRIPTION
This PR adds a new (optional) syntax parameter to the `elasticSearchFormat` function to allow the caller to choose which kind of syntax to use then converting to ElasticSearch query syntax.

For backwards compatibility, this defaults to the syntax used in ES6 and below, but can be changed to use the syntax supported in ES7 and up.

Please note that AFAIK ES7 syntax is also compatible to older versions of ElasticSearch.