### PR TITLE
Improved autocomplete

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Karma tests with debugger",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run test-debug",
+    },
+    {
+      "name": "Attach to Karma",
+      "type": "chrome",
+      "request": "attach",
+      "address": "localhost",
+      "port": 9333,
+      "restart": true,
+      "timeout": 600000,
+      "sourceMaps": true,
+      "webRoot": "${workspaceFolder}/packages/tests",
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - Fix totalQuery structure in mongodb (PR #916) (issue #915)
   - Fixed bug in `loadTree()` (PR #917) (issue #356)
   - Fixed bug on change group value (PR #944) (issue #923)
+  - Fixed render of option titles in Autocomplete AntDesign (PR #947) (issues #930, #942)
+  - Implemented `allowCustomValues` for MUI (PR #947) (issue #327)
+  - Improved autocomplete for MUI and AntD. Mark custom values with coral color (PR #947)
 - 6.2.0
   - Fixed type `Config`: should have render settings like `renderSize` (PR #909) (issue #879)
   - Fixed type for `renderBeforeWidget`: `RuleProps` instead of wrong `FieldProps` (PR #909) (issue #879)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "build-libs": "pnpm --filter @react-awesome-query-builder/examples^... run build",
     "build-examples": "pnpm --filter !@react-awesome-query-builder/examples^... run build",
     "test": "pnpm --filter @react-awesome-query-builder/tests run test",
+    "test-debug": "pnpm --filter @react-awesome-query-builder/tests run test-debug",
     "check-hot": "pnpm -r --parallel --aggregate-output --reporter=append-only check-hot",
     "clean": "sh ./scripts/clean.sh",
     "lint": "pnpm -r --parallel --aggregate-output --reporter=append-only run lint",

--- a/packages/antd/modules/widgets/value/Autocomplete.jsx
+++ b/packages/antd/modules/widgets/value/Autocomplete.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useCallback } from "react";
 import { Select, Spin, Divider } from "antd";
 import { calcTextWidth, SELECT_WIDTH_OFFSET_RIGHT } from "../../utils/domUtils";
 import { Hooks } from "@react-awesome-query-builder/ui";
@@ -23,10 +23,13 @@ export default (props) => {
     aPlaceholder,
     extendOptions,
     getOptionDisabled,
+    getOptionIsCustom,
     getOptionLabel,
+    onInputChange,
   } = useListValuesAutocomplete(props, {
     debounceTimeout: 100,
-    multiple
+    multiple,
+    uif: "antd"
   });
 
   const filteredOptions = extendOptions(options);
@@ -39,10 +42,12 @@ export default (props) => {
 
   const { defaultSelectWidth, defaultSearchWidth, renderSize } = config.settings;
   const placeholderWidth = calcTextWidth(placeholder);
-  const aValue = value && value.length ? value : undefined;
+  const isEmptyValue = multiple ? !value?.length : !value;
+  const aValue = !isEmptyValue ? value : (multiple ? [] : undefined);
   const width = aValue || !placeholderWidth ? null : placeholderWidth + SELECT_WIDTH_OFFSET_RIGHT;
   const dropdownWidth = optionsMaxWidth && !isNaN(optionsMaxWidth) ? optionsMaxWidth + SELECT_WIDTH_OFFSET_RIGHT : null;
   const minWidth = width || defaultSelectWidth;
+  const isClearAllClicked = React.useRef(false);
   
   const style = {
     width: (multiple ? undefined : minWidth),
@@ -52,23 +57,25 @@ export default (props) => {
     width: dropdownWidth,
   };
 
-  const mode = !multiple ? undefined : (allowCustomValues ? "tags" : "multiple");
+  const mode = !multiple ? undefined : (allowCustomValues ? "multiple" : "multiple");
   const dynamicPlaceholder = !readonly ? aPlaceholder : "";
 
   // rendering special 'Load more' option has side effect: on change rc-select will save its title as internal value in own state
   const renderedOptions = filteredOptions?.filter(option => !option.specialValue).map((option) => (
     <Option 
       key={option.value} 
-      value={option.value} 
+      value={option.value}
       disabled={getOptionDisabled(option)}
     >
-      {getOptionLabel(option)}
+      <span className={getOptionIsCustom(option) ? "customSelectOption" : undefined}>
+        {getOptionLabel(option)}
+      </span>
     </Option>
   ));
 
   const onSpecialClick = (specialValue) => () => {
     const option = filteredOptions.find(opt => opt.specialValue == specialValue);
-    onChange(null, option);
+    onChange(null, specialValue, option);
   };
 
   const specialOptions = filteredOptions?.filter(option => !!option.specialValue).map((option) => (
@@ -82,19 +89,69 @@ export default (props) => {
     </a>
   ));
 
-  const aOnSelect = async (label, option) => {
+  const aOnSelect = async (newValue, option) => {
+    // For both multiple/single `newValue` is string, `option` is {value, children}
+    // ! Custom option is always `{}`
     if (isSpecialValue(option)) {
-      await onChange(label, option);
+      await onChange(null, newValue, option);
+    } else {
+      if (multiple) {
+        await onChange(null, newValue, option);
+      }
     }
   };
 
-  const aOnChange = async (label, option) => {
-    if (!isSpecialValue(option)) {
-      await onChange(label, option);
+  const aOnClear = () => {
+    if (open) {
+      // tip: if closed, search is hidden, so let's clear tags AND search value
+      isClearAllClicked.current = true;
     }
   };
 
-  const dropdownRender = (menu) => (
+
+  const aOnChange = async (newValue, option) => {
+    // For multiple `newValue` is array of strings, `option` is array of {value, children}
+    // For single `newValue` is string/undefined, `option` is {value, children}/undefined
+    // ! Custom option is always `{}`
+    //
+    // For multiple called on:
+    // - click (x) at right (clear all)
+    // - tag removal
+    // - option selection (`aOnSelect` is also called after)
+    // - trying to add new tag from search input (for mode "tags" - unwanted!)
+    // 
+    // For single called on:
+    // - click (x) at right (clear all)
+    // - option selection (`aOnSelect` is also called after)
+    // ! NOT when trying to add new tag
+
+    const isAddFromSearch 
+      = multiple
+      && newValue.length && newValue.length > aValue.length
+      && newValue[newValue.length-1] == inputValue;
+    const shouldIgnore = isSpecialValue(option) // use onSelect instead
+      || mode === "tags" && isAddFromSearch // obsolete, we don't use tags mode
+      || isClearAllClicked.current && inputValue // if there are tags AND input, clear input first
+    ;
+    isClearAllClicked.current = false;
+    if (!shouldIgnore) {
+      await onChange(null, newValue, option);
+    }
+  };
+
+  // to keep compatibility with antD
+  const aOnSearch = async (newInputValue) => {
+    if (isClearAllClicked.current) {
+      isClearAllClicked.current = false;
+    }
+    // if (newInputValue === "" && !open) {
+    //   return; // ?
+    // }
+
+    await onInputChange(null, newInputValue);
+  };
+
+  const dropdownRender = useCallback((menu) => (
     <div>
       {menu}
       {specialOptions.length > 0
@@ -106,14 +163,14 @@ export default (props) => {
         </>
       }
     </div>
-  );
+  ), [filteredOptions]);
 
   return (
     <Select
       filterOption={useAsyncSearch ? false : true}
       dropdownRender={dropdownRender}
       allowClear={true}
-      notFoundContent={isLoading ? "Loading..." : null}
+      notFoundContent={isLoading ? "Loading..." : "Not found"}
       disabled={readonly}
       mode={mode}
       style={customProps?.style || style}
@@ -123,14 +180,15 @@ export default (props) => {
       placeholder={customProps?.placeholder || dynamicPlaceholder}
       onDropdownVisibleChange={onDropdownVisibleChange}
       onChange={aOnChange}
+      onClear={aOnClear}
       onSelect={aOnSelect}
-      onSearch={onSearch}
+      onSearch={aOnSearch}
       showArrow
       showSearch
       size={renderSize}
       loading={isLoading}
       value={aValue}
-      //searchValue={inputValue}
+      searchValue={inputValue}
       open={open}
       {...customProps}
     >

--- a/packages/antd/styles/fixes.scss
+++ b/packages/antd/styles/fixes.scss
@@ -46,3 +46,7 @@ ul.ant-select-selection__rendered {
 .widget--valuesrc span .anticon-ellipsis {
   transform: rotate(90deg);
 }
+
+.customSelectOption {
+  color: lightcoral;
+}

--- a/packages/core/modules/utils/autocomplete.js
+++ b/packages/core/modules/utils/autocomplete.js
@@ -1,10 +1,13 @@
 import {sleep} from "./stuff";
-import {listValuesToArray, mapListValues} from "./listValues";
+import {listValuesToArray, getListValue, makeCustomListValue} from "./listValues";
 
 export const simulateAsyncFetch = (all, cPageSize = 0, delay = 1000) => async (search, offset, meta) => {
   const pageSize = meta?.pageSize != undefined ? meta.pageSize : cPageSize;
   const filtered = listValuesToArray(all)
-    .filter(({title}) => search == null ? true : title.toUpperCase().indexOf(search.toUpperCase()) != -1);
+    .filter(({title, value}) => search == null ? true : (
+      title.toUpperCase().indexOf(search.toUpperCase()) != -1
+      || `${value}`.toUpperCase().indexOf(search.toUpperCase()) != -1
+    ));
   const pages = pageSize ? Math.ceil(filtered.length / pageSize) : 0;
   const currentOffset = offset || 0;
   const currentPage = pageSize ? Math.ceil(currentOffset / pageSize) : null;
@@ -23,31 +26,59 @@ export const simulateAsyncFetch = (all, cPageSize = 0, delay = 1000) => async (s
   };
 };
 
-export const mergeListValues = (values, newValues, toStart = false) => {
+export const mergeListValues = (values, newValues, toStart = false, hideNewValues = false) => {
   if (!newValues)
     return values;
   const old = values || [];
-  const newFiltered = newValues.filter(v => old.find(av => av.value == v.value) == undefined);
+  const newFiltered = newValues
+    .filter(v => old.find(av => ""+av.value == ""+v.value) == undefined)
+    .map(v => (hideNewValues ? {...v, isHidden: true} : v));
   const merged = toStart ? [...newFiltered, ...old] : [...old, ...newFiltered];
   return merged;
 };
 
+export const optionToListValue = (val, listValues, allowCustomValues) => {
+  const v = val == null || val == "" ? undefined : (val?.value ?? val);
+  const item = getListValue(v, listValues);
+  const customItem = allowCustomValues && !item ? makeCustomListValue(v) : undefined;
+  const listValue = item || customItem;
+  const lvs = listValue ? [listValue] : undefined; //not allow []
+  return [v, lvs];
+};
+
+export const optionsToListValues = (vals, listValues, allowCustomValues) => {
+  const newSelectedListValues = vals.map((val, _i) => {
+    const v = val == null || val == "" ? undefined : (val?.value ?? val);
+    const item = getListValue(v, listValues);
+    const customItem = allowCustomValues && !item ? makeCustomListValue(v) : undefined;
+    const listValue = item || customItem;
+    return listValue;
+  }).filter(o => o != undefined);
+  let newSelectedValues = newSelectedListValues
+    .map(o => (o?.value ?? o));
+  if (!newSelectedValues.length)
+    newSelectedValues = undefined; //not allow []
+  return [newSelectedValues, newSelectedListValues];
+};
+
 export const listValueToOption = (lv) => {
   if (lv == null) return null;
-  const {title, children, value, disabled, groupTitle, renderTitle} = lv;
-  let option = {title, value};
-  if (!title && children)
-    title = children
+  const {title, value, disabled, groupTitle, renderTitle, children, label, isCustom, isHidden} = lv;
+  let option = {
+    value,
+    title: title || label || children, // fix issue #930 for AntD
+  };
   if (disabled)
     option.disabled = disabled;
   if (groupTitle)
     option.groupTitle = groupTitle;
   if (renderTitle)
     option.renderTitle = renderTitle;
+  if (isCustom)
+    option.isCustom = isCustom;
+  if (isHidden)
+    option.isHidden = isHidden;
   return option;
 };
 
-export const getListValue = (selectedValue, listValues) => 
-  mapListValues(listValues, (lv) => (lv.value === selectedValue ? lv : null))
-    .filter(v => v !== null)
-    .shift();
+export { getListValue };

--- a/packages/core/modules/utils/validation.js
+++ b/packages/core/modules/utils/validation.js
@@ -306,10 +306,13 @@ const validateNormalValue = (leftField, field, value, valueSrc, valueType, async
     const jsType = wConfig.jsType;
     const fieldSettings = fieldConfig.fieldSettings;
     const listValues = fieldSettings?.treeValues || fieldSettings?.listValues;
+    const isAsyncListValues = !!fieldSettings?.asyncFetch;
+    // todo: for select/multiselect value can be string or number
+    const canSkipCheck = listValues || isAsyncListValues; 
 
     if (valueType && valueType != wType)
       return [`Value should have type ${wType}, but got value of type ${valueType}`, value];
-    if (jsType && !isTypeOf(value, jsType) && !listValues) { //tip: can skip type check for listValues
+    if (jsType && !isTypeOf(value, jsType) && !canSkipCheck) {
       return [`Value should have JS type ${jsType}, but got value of type ${typeof value}`, value];
     }
 

--- a/packages/material/styles/fixes.scss
+++ b/packages/material/styles/fixes.scss
@@ -1,0 +1,3 @@
+.customSelectOption {
+  color: lightcoral;
+}

--- a/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
+++ b/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
@@ -5,14 +5,12 @@ import FormControl from "@mui/material/FormControl";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
 import CircularProgress from "@mui/material/CircularProgress";
 import Chip from "@mui/material/Chip";
-import Checkbox from "@mui/material/Checkbox";
-import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
-import CheckBoxIcon from "@mui/icons-material/CheckBox";
+import MenuItem from "@mui/material/MenuItem";
+import Check from "@mui/icons-material/Check";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 import { Hooks } from "@react-awesome-query-builder/ui";
 const { useListValuesAutocomplete } = Hooks;
-
-const nonCheckedIcon = <CheckBoxOutlineBlankIcon fontSize="small" />;
-const checkedIcon = <CheckBoxIcon fontSize="small" />;
 const defaultFilterOptions = createFilterOptions();
 const emptyArray = [];
 
@@ -39,15 +37,18 @@ export default (props) => {
     extendOptions,
     getOptionSelected,
     getOptionDisabled,
+    getOptionIsCustom,
     getOptionLabel,
+    selectedListValue,
   } = useListValuesAutocomplete(props, {
     debounceTimeout: 100,
-    multiple
+    multiple,
+    uif: "mui"
   });
 
   // setings
   const {defaultSelectWidth, defaultSearchWidth} = config.settings;
-  const {width, showCheckboxes, ...rest} = customProps || {};
+  const {width, ...rest} = customProps || {};
   let customInputProps = rest.input || {};
   const inputWidth = customInputProps.width || defaultSearchWidth; // todo: use as min-width for Autocomplete comp
   customInputProps = omit(customInputProps, ["width"]);
@@ -72,10 +73,19 @@ export default (props) => {
 
   // render
   const renderInput = (params) => {
+    // parity with Antd
+    const shouldRenderSelected = !multiple && !open;
+    const selectedTitle = selectedListValue?.title ?? "";
+    const shouldHide = multiple && !open;
+    const value = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? "");
     return (
       <TextField 
         variant="standard"
-        {...params} 
+        {...params}
+        inputProps={{
+          ...params.inputProps,
+          value,
+        }}
         InputProps={{
           ...params.InputProps,
           readOnly: readonly,
@@ -96,8 +106,10 @@ export default (props) => {
 
   const renderTags = (value, getTagProps) => value.map((option, index) => {
     return <Chip
-      key={index}
+      key={option.value}
       label={getOptionLabel(option)}
+      size={"small"}
+      variant={getOptionIsCustom(option) ? "outlined" : "filled"}
       {...getTagProps({ index })}
     />;
   });
@@ -107,22 +119,31 @@ export default (props) => {
   };
 
   const renderOption = (props, option) => {
-    const { title, renderTitle, value } = option;
-    const selected = (selectedValue || []).includes(value);
+    const { title, renderTitle, value, isHidden } = option;
+    const isSelected = multiple ? (selectedValue || []).includes(value) : selectedValue == value;
+    const className = getOptionIsCustom(option) ? "customSelectOption" : undefined;
+    const titleSpan = (
+      <span className={className}>
+        {renderTitle || title}
+      </span>
+    );
+    if (isHidden)
+      return null;
     if (option.specialValue) {
       return <div {...props}>{renderTitle || title}</div>;
-    } else if (multiple && showCheckboxes != false) {
-      return <div {...props}>
-        <Checkbox
-          icon={nonCheckedIcon}
-          checkedIcon={checkedIcon}
-          style={{ marginRight: 8 }}
-          checked={selected}
-        />
-        {title}
-      </div>;
+    } else if (multiple) {
+      return (
+        <MenuItem
+          {...props}
+          size={"small"}
+          selected={isSelected}
+        >
+          {!isSelected && <ListItemText inset>{titleSpan}</ListItemText>}
+          {isSelected && <><ListItemIcon><Check /></ListItemIcon>{titleSpan}</>}
+        </MenuItem>
+      );
     } else {
-      return <div {...props}>{renderTitle || title}</div>;
+      return <div {...props}>{titleSpan}</div>;
     }
   };
 
@@ -150,7 +171,7 @@ export default (props) => {
         getOptionLabel={getOptionLabel}
         getOptionDisabled={getOptionDisabled}
         renderInput={renderInput}
-        //renderTags={renderTags}
+        renderTags={renderTags}
         renderOption={renderOption}
         filterOptions={filterOptions}
         isOptionEqualToValue={isOptionEqualToValue}

--- a/packages/mui/styles/fixes.scss
+++ b/packages/mui/styles/fixes.scss
@@ -1,3 +1,7 @@
 .MuiIconButton-sizeSmall {
   padding: 3px; // smaller button
 }
+
+.customSelectOption {
+  color: lightcoral;
+}

--- a/packages/tests/karma.conf.js
+++ b/packages/tests/karma.conf.js
@@ -9,6 +9,7 @@ process.env.TZ = "Etc/UTC";
 process.env.BABEL_ENV = "test"; // Set the proper environment for babel
 
 const isCI = !!process.env.CI;
+const isDebug = !!process.env.TEST_DEBUG;
 
 module.exports = function(config) {
   config.set({
@@ -42,7 +43,7 @@ module.exports = function(config) {
       stats: "errors-only"
     },
 
-    reporters: isCI ? ["mocha", "junit", "coverage"] : ["progress", "coverage"],
+    reporters: isCI ? ["mocha", "junit", "coverage"] : isDebug ? ["progress"] : ["progress", "coverage"],
 
     junitReporter: {
       outputDir: "junit",
@@ -67,14 +68,29 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    browsers: ["ChromeHeadlessNoSandbox"],
+    browsers: isDebug ? ["ChromeWithDebugging"] : ["ChromeHeadlessNoSandbox"],
     customLaunchers: {
+      ChromeWithDebugging: {
+        base: 'Chrome',
+        flags: [
+          "--no-sandbox", 
+          "--remote-debugging-port=9333"
+        ],
+        debug: true,
+      },
       ChromeHeadlessNoSandbox: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox", "--disable-setuid-sandbox"]
+        flags: [
+          "--no-sandbox",
+          "--disable-setuid-sandbox"
+        ],
       }
     },
     singleRun: true,
-    concurrency: 1
+    concurrency: 1,
+    // captureTimeout: 60000,
+    browserDisconnectTimeout : isDebug ? 1000*60*10 : 1000*20,
+    browserDisconnectTolerance : isDebug ? 1 : 0,
+    browserNoActivityTimeout : isDebug ? 1000*60 : 1000*30,
   });
 };

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -17,6 +17,7 @@
     "lint": "npm run eslint && npm run tsc",
     "lint-fix": "eslint --ext .jsx --ext .js --ext .tsx --ext .ts --fix  ./specs/ ./support/",
     "test": "karma start ./karma.conf.js",
+    "test-debug": "TEST_DEBUG=1 karma start ./karma.conf.js --debug",
     "tsc": "tsc -p . --noEmit"
   },
   "dependencies": {

--- a/packages/tests/specs/Autocomplete.js
+++ b/packages/tests/specs/Autocomplete.js
@@ -1,0 +1,131 @@
+import { getAutocompleteUtils } from "../support/autocomplete";
+import * as configs from "../support/configs";
+import * as inits from "../support/inits";
+
+export const autocompleteTestsFor = (uif, uifv, it, with_qb) => {
+  const {
+    ctx,
+    createCtx,
+    setStep,
+    updateSelect,
+    waitAndUpdate,
+    expectInput,
+    expectSelected,
+    clickClear,
+    expectOptions,
+    expectTags,
+    expectVisibleOptions,
+    selectOption,
+    unselectOption,
+    deleteTag,
+    openSelect,
+    closeSelect,
+    expectOpened,
+    enterSearch,
+    clickLoadMore,
+  } = getAutocompleteUtils(uif, uifv);
+
+
+  const testsSingleStrict = () => {
+    it("should load more, search, close", async () => {
+      await with_qb(configs.with_autocomplete, inits.with_autocomplete_strict_a, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
+        createCtx({qb, multiple: false, strict: true});
+        expectInput("a");
+        if (uif === "mui")
+          expectOptions("a_a");
+    
+        // should load A from 1st page
+        setStep("wait");
+        await waitAndUpdate();
+        expectInput("a");
+    
+        setStep("open");
+        await openSelect();
+        expectOptions("a_A;aa_AA;aaa1_AAA1");
+        expectInput("");
+        if (uif == "antd")
+          expectSelected("A");
+    
+        setStep("load more");
+        await clickLoadMore();
+        expectOptions("a_A;aa_AA;aaa1_AAA1;aaa2_AAA2;b_B;c_C");
+        expectOpened(true);
+
+        setStep("search b");
+        await enterSearch("b");
+        if (uif === "mui")
+          expectOptions("a_a;b_B");
+        expectVisibleOptions("B");
+        expectInput("b");
+    
+        // setStep("clear");
+        // await clickClear();
+        // expectInput("");
+    
+        // should reset
+        setStep("close");
+        await closeSelect({increaseTimeout: 2});
+        expectInput("A");
+      }, {
+        attach: true
+      });
+    });
+  };
+
+
+  const testsMultipleStrict = () => {
+    it("should select, unselect, del tag", async () => {
+      await with_qb(configs.with_autocomplete, inits.with_autocomplete_multi_strict_a, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
+        createCtx({qb, multiple: true, strict: true});
+        expectInput("");
+        if (uif === "mui")
+          expectOptions("a_a");
+        expectTags("a");
+    
+        setStep("open");
+        await openSelect();
+        expectInput("");
+        expectOptions("a_A;aa_AA;aaa1_AAA1");
+        expectTags("A");
+    
+        setStep("select AA");
+        await selectOption("AA");
+        expectTags("A;AA");
+    
+        setStep("unselect AA");
+        await unselectOption("AA");
+        expectTags("A");
+    
+        setStep("select AA #2");
+        await selectOption("AA");
+        expectTags("A;AA");
+    
+        setStep("del tag A");
+        await deleteTag("A");
+        expectTags("AA");
+    
+        setStep("clear");
+        await clickClear();
+        expectInput("");
+        expectTags("");
+    
+        // setStep("search b");
+        // await enterSearch("b");
+        // expectOptions("a_a;b_B");
+        // expectVisibleOptions("B");
+    
+        // setStep("close");
+        // await closeSelect();
+        // expectInput("");
+      }, {
+        attach: true
+      });
+    });
+  };
+
+
+  return {
+    testsSingleStrict,
+    testsMultipleStrict,
+  };
+};

--- a/packages/tests/specs/InteractionsAntd.test.js
+++ b/packages/tests/specs/InteractionsAntd.test.js
@@ -1,37 +1,26 @@
 import * as configs from "../support/configs";
 import * as inits from "../support/inits";
 import { with_qb_ant, sleep } from "../support/utils";
-
-const stringifyOptions = (ac) => {
-  return ac
-    .find("Popup") // in portal
-    .find("OptionList")
-    .find("Item")
-    .getElements()
-    .map(el => el.key)
-    .join(";");
-};
+import { autocompleteTestsFor } from "./Autocomplete";
 
 describe("interactions on antd", () => {
 
   describe("autocomplete", () => {
-    it("find B", async () => {
-      await with_qb_ant(configs.with_autocomplete, inits.with_autocomplete_a, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
-        let ac = qb.find("Select").filterWhere(s => s.props()?.placeholder == "Select value");
-        expect(ac.prop("value")).to.eq("a");
+    const {
+      testsSingleStrict,
+      testsMultipleStrict,
+    } = autocompleteTestsFor("antd", null, it, with_qb_ant);
 
-        ac.prop("onDropdownVisibleChange")(true);
-        qb.update();
-        expect(stringifyOptions(qb)).to.eq("a");
-        
-        ac.prop("onSearch")("b");
-        await sleep(400); // should be > 50ms delay
-        qb.update();
-        ac = qb.find("Select").filterWhere(s => s.props()?.placeholder == "Select value");
-        expect(stringifyOptions(qb)).to.eq("a;b");
-      });
+    describe("single-strict", () => {
+      testsSingleStrict();
+    });
+
+    describe("multiple-strict", () => {
+      testsMultipleStrict();
     });
   });
+
+  // -------
 
   it("set not", async () => {
     await with_qb_ant(configs.simple_with_numbers_and_str, inits.with_number, "JsonLogic", (qb, onChange, {expect_jlogic}) => {

--- a/packages/tests/specs/InteractionsMaterial.test.js
+++ b/packages/tests/specs/InteractionsMaterial.test.js
@@ -1,30 +1,27 @@
 import * as configs from "../support/configs";
 import * as inits from "../support/inits";
-import { with_qb_material, sleep } from "../support/utils";
-import Autocomplete from "@material-ui/lab/Autocomplete";
+import { with_qb_material } from "../support/utils";
 import { expect } from "chai";
-
-const stringifyOptions = (options) => {
-  return options.map(({title, value}) => `${value}_${title}`).join(";");
-};
+import { autocompleteTestsFor } from "./Autocomplete";
 
 describe("interactions on Material-UI", () => {
 
   describe("autocomplete", () => {
-    it("find B", async () => {
-      await with_qb_material(configs.with_autocomplete, inits.with_autocomplete_a, "JsonLogic", async (qb, onChange, {expect_jlogic}) => {
-        let ac = qb.find(Autocomplete).filter({label: "Select value"});
-        expect(stringifyOptions(ac.prop("options"))).to.eq("a_a");
-        
-        ac.prop("onInputChange")(null, "b");
-        await sleep(200); // should be > 50ms delay
-        qb.update();
-        ac = qb.find(Autocomplete).filter({label: "Select value"});
+    const {
+      testsSingleStrict,
+      testsMultipleStrict,
+    } = autocompleteTestsFor("mui", 4, it, with_qb_material);
 
-        expect(stringifyOptions(ac.prop("options"))).to.eq("a_a;b_B");
-      });
+    describe("single-strict", () => {
+      testsSingleStrict();
+    });
+
+    describe("multiple-strict", () => {
+      testsMultipleStrict();
     });
   });
+
+  //-------
 
   it("should render labels with showLabels=true", async () => {
     await with_qb_material([configs.with_different_groups, configs.with_settings_show_labels], inits.with_different_groups, "JsonLogic", (qb) => {

--- a/packages/tests/specs/InteractionsMui.test.js
+++ b/packages/tests/specs/InteractionsMui.test.js
@@ -1,12 +1,30 @@
 import * as configs from "../support/configs";
 import * as inits from "../support/inits";
-import { with_qb_mui, sleep } from "../support/utils";
+import { with_qb_mui } from "../support/utils";
 import Slider from "@mui/material/Slider";
 import TextField from "@mui/material/TextField";
 import { expect } from "chai";
+import { autocompleteTestsFor } from "./Autocomplete";
 
 
 describe("interactions on MUI", () => {
+  describe("autocomplete", () => {
+    const {
+      testsSingleStrict,
+      testsMultipleStrict,
+    } = autocompleteTestsFor("mui", 5, it, with_qb_mui);
+
+    describe("single-strict", () => {
+      testsSingleStrict();
+    });
+
+    describe("multiple-strict", () => {
+      testsMultipleStrict();
+    });
+  });
+
+  //-------
+
   it("change range slider value", async () => {
     await with_qb_mui(configs.with_all_types, inits.with_range_slider, "JsonLogic", (qb, onChange, {expect_jlogic, expect_checks}) => {
       expect_checks({

--- a/packages/tests/support/autocomplete.js
+++ b/packages/tests/support/autocomplete.js
@@ -1,6 +1,12 @@
 
 import { Utils } from "@react-awesome-query-builder/core";
 const { simulateAsyncFetch } = Utils.Autocomplete;
+import { expect } from "chai";
+import MuiAutocomplete from "@mui/material/Autocomplete";
+import MaterialAutocomplete from "@material-ui/lab/Autocomplete";
+import { sleep } from "./utils";
+
+//-------
 
 const demoListValues = [
   {title: "A", value: "a"},
@@ -18,5 +24,355 @@ const demoListValues = [
   {title: "J", value: "j"},
 ];
 
-// 50ms delay, 3 per page
-export const simulatedAsyncFetch = simulateAsyncFetch(demoListValues, 3, 50);
+// 10ms delay, 3 per page
+export const simulatedAsyncFetch = simulateAsyncFetch(demoListValues, 3, 10);
+
+//-------
+
+export const getAutocompleteUtils = (uif, uifv) => {
+  let ctx = {
+    qb: undefined,
+    ac: undefined,
+    multiple: undefined,
+    strict: undefined,
+    step: undefined,
+  };
+
+  const createCtx = ({qb, multiple, strict}) => {
+    ctx = {
+      qb,
+      multiple,
+      strict,
+      ac: undefined,
+      step: "init",
+    };
+    updateSelect();
+    return ctx;
+  };
+
+  const setStep = (step) => {
+    ctx.step = step;
+  };
+
+  const updateSelect = () => {
+    const {qb, multiple} = ctx;
+    let ac;
+    const targetPlaceholder = multiple ? "Select values" : "Select value";
+    if (uif === "mui") {
+      const Autocomplete = uifv === 4 ? MaterialAutocomplete : MuiAutocomplete;
+      ac = qb
+        .find(Autocomplete)
+        .filter({label: targetPlaceholder});
+    } else {
+      ac = qb
+        .find("Select")
+        .filterWhere(s => s.props()?.placeholder == targetPlaceholder);
+    }
+    ctx.ac = ac;
+  };
+
+  const waitAndUpdate = async ({
+    timeout = 100,
+    increaseTimeout = 1,
+  } = {}) => {
+    const finalTimeout = timeout * (increaseTimeout || 1);
+    const {qb} = ctx;
+    await sleep(finalTimeout); // should be > 50ms delay
+    qb.update();
+    updateSelect();
+  };
+
+  const stringifyOptions = () => {
+    const {qb, ac} = ctx;
+    if (uif === "mui") {
+      const options = ac.prop("options");
+      return options.map(({title, value}) => `${value}_${title}`).join(";");
+    } else {
+      return stringifyVisibleOptions(true);
+    }
+  };
+
+  const stringifyVisibleOptions = (withValues = false) => {
+    const {qb, ac, multiple} = ctx;
+    if (uif === "mui") {
+      const targetType = !multiple && uifv == 5 ? "div" : "li";
+      const options = ac
+        .find(".MuiAutocomplete-listbox .MuiAutocomplete-option")
+        .filterWhere(o => {
+          return o.getElement()?.type == targetType;
+        });
+      return options.map(o => o.text()).join(";");
+    } else {
+      const items = ac
+        .find("Popup") // in portal
+        .find("OptionList")
+        .find("Item");
+      return items
+        .getElements()
+        .map((el, i) => 
+          withValues
+            ? `${el.key}_${items.at(i).text()}`
+            : `${items.at(i).text()}`
+        )
+        .join(";");
+    }
+  };
+
+  const stringifyTags = (withValues = false) => {
+    const {qb, ac} = ctx;
+    if (uif === "mui") {
+      const chips = ac
+        .find(".MuiChip-root")
+        .filterWhere(o => {
+          return o.getElement()?.type == "div";
+        });
+      return chips
+        .map((o, i) => {
+          return o.text();
+        })
+        .join(";");
+    } else {
+      const items = ac
+        .find("Selector")
+        .find("Item")
+        .filterWhere(o => {
+          // last Item contains Input and has no key
+          return !!o.key();
+        });
+      return items
+        .getElements()
+        .map((el, i) => 
+          withValues
+            ? `${el.key}_${items.at(i).text()}`
+            : `${items.at(i).text()}`
+        )
+        .join(";");
+    }
+  };
+
+  const expectInput = (expectedValue) => {
+    const {qb, ac, step, multiple} = ctx;
+    let textInputValue;
+    if (uif === "mui") {
+      const textInput = qb
+        .find(".rule--widget .MuiAutocomplete-root .MuiInput-root input");
+      textInputValue = textInput.getDOMNode().getAttribute("value");
+    } else {
+      const selector = ac.find("Selector");
+      const textInput = selector.find("Input");
+      // for single - selected title is shown on closed, search value on opened
+      //  if "A" is selected and user clicks on search, "" is shown
+      textInputValue = !ac.prop("open") && !multiple ? selector.text() : textInput.prop("value");
+    }
+    expect(textInputValue, `${step} - textInput`).to.eq(expectedValue);
+  };
+
+  const expectSelected = (expected) => {
+    const {qb, ac, step, multiple} = ctx;
+    let actualValue;
+    if (uif === "mui") {
+      const textInput = qb
+        .find(".rule--widget .MuiAutocomplete-root .MuiInput-root input");
+      actualValue = textInput.getDOMNode().getAttribute("value");
+    } else {
+      const selector = ac.find("Selector");
+      actualValue = selector.text();
+    }
+    expect(actualValue, `${step} - selected`).to.eq(expected);
+  };
+
+  const clickClear = async () => {
+    const {qb, ac, step} = ctx;
+    if (uif === "mui") {
+      const targetType = "button";
+      const clearCmp = ac
+        .find(".MuiAutocomplete-clearIndicator")
+        .filterWhere(o => {
+          return o.getElement()?.type == targetType;
+        });
+      clearCmp.prop("onClick")();
+    } else {
+      const closeBtn = ac
+        .find("Select")
+        .find("TransBtn")
+        .filterWhere(btn => {
+          return btn.props().className?.split(" ").includes("ant-select-clear");
+        });
+      expect(closeBtn.length, `${step} - closeBtn`).to.eq(1);
+      closeBtn.at(0).simulate("mouseDown");
+    }
+    await waitAndUpdate();
+  };
+
+  const expectOptions = (expectedOptions) => {
+    const {step} = ctx;
+    expect(stringifyOptions(), `${step} - options`).to.eq(expectedOptions);
+  };
+
+  const expectTags = (expectedTags) => {
+    const {step} = ctx;
+    expect(stringifyTags(), `${step} - tags`).to.eq(expectedTags);
+  };
+
+  const expectVisibleOptions = (expectedOptions) => {
+    const {step} = ctx;
+    expect(stringifyVisibleOptions(), `${step} - visibleOptions`).to.eq(expectedOptions);
+  };
+
+  const clickLoadMore = async () => {
+    const {qb, ac, step, multiple} = ctx;
+    if (uif === "antd") {
+      document.querySelector(
+        ".ant-select-dropdown .ant-divider"
+      )?.nextSibling?.querySelector("a")?.click();
+    } else {
+      await selectOption("Load more...");
+    }
+    await waitAndUpdate();
+  };
+
+  const selectOption = async (targetTitle, expectedIsSelected = false) => {
+    const {qb, ac, step, multiple} = ctx;
+    if (uif === "antd") {
+      const items = ac
+        .find("Popup") // in portal
+        .find("OptionList")
+        .find("Item");
+      const targetItems = items
+        .filterWhere(it => it.text() == targetTitle);
+        //.filterWhere(it => it.getElement().key == targetValue);
+      expect(targetItems.length).to.eq(1);
+      //todo: check selected
+      targetItems.at(0).simulate("click");
+    } else {
+      const targetType = !multiple && uifv == 5 ? "div" : "li";
+      const options = ac
+        .find(".MuiAutocomplete-listbox .MuiAutocomplete-option")
+        .filterWhere(o => {
+          return o.getElement()?.type == targetType;
+        });
+      const targetOption = options.filterWhere(o => {
+        return o.text() == targetTitle;
+      });
+      const isSelected = uifv == 5
+        ? targetOption.last().getDOMNode().className.includes("Mui-selected")
+        : targetOption.last().getDOMNode().getAttribute("aria-selected") == "true";
+      if (expectedIsSelected != undefined)
+        expect(isSelected, `${step} - ${targetTitle} isSelected`).to.eq(expectedIsSelected);
+      targetOption.last().simulate("click");
+    }
+    await waitAndUpdate();
+  };
+
+  const unselectOption = async (targetTitle) => {
+    return await selectOption(targetTitle, true);
+  };
+
+  const deleteTag = async (targetTitle) => {
+    const {qb, ac} = ctx;
+    if (uif == "mui") {
+      const chips = ac
+        .find(".MuiChip-root")
+        .filterWhere(o => {
+          return o.getElement()?.type == "div";
+        });
+      const targetChip = chips.findWhere(o => {
+        return o.text() == targetTitle;
+      });
+      const deleteIcon = targetChip
+        .find(".MuiChip-deleteIcon");
+      deleteIcon.last().simulate("click");
+    } else {
+      const items = ac
+        .find("Selector")
+        .find("Item")
+        .filterWhere(o => {
+          // last Item contains Input and has no key
+          return !!o.key();
+        });
+      const targetItem = items.findWhere(o => {
+        return o.text() == targetTitle;
+      });
+      const deleteIcon = targetItem
+        .find("TransBtn");
+      deleteIcon.last().simulate("click");
+    }
+
+    await waitAndUpdate();
+  };
+
+  const openSelect = async () => {
+    const {qb, ac} = ctx;
+    if (uif == "mui") {
+      ac.prop("onOpen")();
+      qb
+        .find(".rule--widget .MuiAutocomplete-root .MuiInput-root input")
+        .simulate("click");
+    } else {
+      ac.prop("onDropdownVisibleChange")(true);
+      qb
+        .find(".rule--widget .ant-select-selection-search input")
+        .simulate("click");
+    }
+    await waitAndUpdate();
+  };
+  
+  const closeSelect = async (opts) => {
+    const {qb, ac} = ctx;
+    if (uif == "mui") {
+      ac.prop("onClose")();
+      qb
+        .find(".rule--widget .MuiAutocomplete-root .MuiInput-root input")
+        .simulate("blur");
+    } else {
+      ac.prop("onDropdownVisibleChange")(false);
+      qb
+        .find(".rule--widget .ant-select-selection-search input")
+        .simulate("blur");
+    }
+    await waitAndUpdate(opts);
+  };
+
+  const expectOpened = (expectedOpen = true) => {
+    const {qb, ac, step} = ctx;
+    const open = ac.prop("open");
+    expect(open, `${step} - open`).to.eq(expectedOpen);
+  };
+
+  const enterSearch = async (inputValue) => {
+    const {qb, ac} = ctx;
+    if (uif == "mui") {
+      ac.prop("onInputChange")(null, inputValue);
+      // qb
+      //   .find(".rule--widget .MuiAutocomplete-root .MuiInput-root input")
+      //   .simulate("change", { target: { value: inputValue } });
+    } else {
+      ac.prop("onSearch")(inputValue);
+    }
+    await waitAndUpdate({increaseTimeout: 2});
+  };
+
+  return {
+    ctx,
+    createCtx,
+    setStep,
+    updateSelect,
+    waitAndUpdate,
+    expectInput,
+    expectSelected,
+    clickClear,
+    expectOptions,
+    expectTags,
+    expectVisibleOptions,
+    selectOption,
+    unselectOption,
+    deleteTag,
+    openSelect,
+    closeSelect,
+    expectOpened,
+    enterSearch,
+    clickLoadMore,
+  };
+};
+
+//-------

--- a/packages/tests/support/configs.js
+++ b/packages/tests/support/configs.js
@@ -966,6 +966,30 @@ export const with_group_array_custom_operator = (BasicConfig) => ({
 export const with_autocomplete = (BasicConfig) => ({
   ...BasicConfig,
   fields: {
+    autocompleteStrict: {
+      label: "AutocompleteStrict",
+      type: "select",
+      valueSources: ["value"],
+      fieldSettings: {
+        asyncFetch: simulatedAsyncFetch,
+        useAsyncSearch: true,
+        useLoadMore: true,
+        forceAsyncSearch: false,
+        allowCustomValues: false
+      },
+    },
+    autocompleteMultipleStrict: {
+      label: "AutocompleteMultipleStrict",
+      type: "multiselect",
+      valueSources: ["value"],
+      fieldSettings: {
+        asyncFetch: simulatedAsyncFetch,
+        useAsyncSearch: true,
+        useLoadMore: true,
+        forceAsyncSearch: false,
+        allowCustomValues: false
+      },
+    },
     autocomplete: {
       label: "Autocomplete",
       type: "select",
@@ -975,7 +999,19 @@ export const with_autocomplete = (BasicConfig) => ({
         useAsyncSearch: true,
         useLoadMore: true,
         forceAsyncSearch: false,
-        allowCustomValues: false
+        allowCustomValues: true
+      },
+    },
+    autocompleteMultiple: {
+      label: "AutocompleteMultiple",
+      type: "multiselect",
+      valueSources: ["value"],
+      fieldSettings: {
+        asyncFetch: simulatedAsyncFetch,
+        useAsyncSearch: true,
+        useLoadMore: true,
+        forceAsyncSearch: false,
+        allowCustomValues: true
       },
     },
   },

--- a/packages/tests/support/inits.js
+++ b/packages/tests/support/inits.js
@@ -899,11 +899,24 @@ export const with_group_array_custom_operator = {
   ]
 };
 
-export const with_autocomplete_a = {
+export const with_autocomplete_strict_a = {
   "and": [{
     "==": [
-      { "var": "autocomplete" },
+      { "var": "autocompleteStrict" },
       "a"
+    ]
+  }]
+};
+
+export const with_autocomplete_multi_strict_a = {
+  "and": [{
+    "all": [
+      { "var": "autocompleteMultipleStrict" },
+      { "in": [{ "var": "" },
+        [
+          "a"
+        ]
+      ]}
     ]
   }]
 };

--- a/packages/tests/webpack.config.js
+++ b/packages/tests/webpack.config.js
@@ -10,10 +10,13 @@ const BOOTSTRAP = path.resolve(__dirname, "../bootstrap/modules");
 const FLUENT = path.resolve(__dirname, "../fluent/modules");
 const TESTS = path.resolve(__dirname);
 
+const isDebug = !!process.env.TEST_DEBUG;
 
 module.exports = {
     mode: "development",
-    devtool: 'source-map', // required for adequate coverage data
+    // source-map is needed for adequate coverage data
+    // inline-source-map is needed for debugging tests
+    devtool: isDebug ? 'inline-source-map' : 'source-map',
     plugins: [
       new webpack.DefinePlugin({
         'process.env': {

--- a/packages/ui/styles/styles.scss
+++ b/packages/ui/styles/styles.scss
@@ -719,5 +719,3 @@ $rule_actions: (".widget--valuesrc", ".rule--drag-handler", ".rule--header") !de
     }
   }
 }
-
-


### PR DESCRIPTION
  - Fixed render of option titles in Autocomplete AntDesign (issues #930, #942)
  - Implemented `allowCustomValues` for MUI  (issue #327)
  - Improved autocomplete for MUI and AntD. Mark custom values with coral color 
  - Added tests