### PR TITLE
Make getOptionLabel always return a string

### DIFF
--- a/packages/ui/modules/hooks/useListValuesAutocomplete.jsx
+++ b/packages/ui/modules/hooks/useListValuesAutocomplete.jsx
@@ -346,13 +346,13 @@ const useListValuesAutocomplete = ({
     }
     if (!option && allowCustomValues) {
       // there is just string value, it's not item from list
-      return valueOrOption;
+      return valueOrOption.toString();
     }
     if (!option) {
       // weird
-      return valueOrOption;
+      return valueOrOption.toString();
     }
-    return option.title || option.label || option.value; // fallback to value
+    return option.title || option.label || option.value.toString(); // fallback to value
   };
 
   const fixedOptions = uif === "mui" ? fixListValuesGroupOrder(options) : options;


### PR DESCRIPTION
MUI expects the label to always be a string, even if the option value is a number. Failing to provide a string gives the warning:

```
MUI: The `getOptionLabel` method of Autocomplete returned number(x) instead of a string for x.
```