### PR TITLE
Show imported value initially in MUI autocomplete inputs

### DIFF
--- a/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
+++ b/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
@@ -99,17 +99,17 @@ export default (props) => {
   const renderInput = (params) => {
     // parity with Antd
     const shouldRenderSelected = !multiple && !open;
-    const selectedTitle = selectedListValue?.title ?? "";
+    const selectedTitle = selectedListValue?.title ?? value.toString();
     const shouldHide = multiple && !open;
-    const value = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? "");
+    const renderValue = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? value.toString());
     return (
       <TextField 
         variant="standard"
         {...params}
         inputProps={{
-          ...params.inputProps,
-          value,
           "aria-label": ariaLabel,
+          ...params.inputProps,
+          value: renderValue,
         }}
         InputProps={{
           ...params.InputProps,

--- a/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
+++ b/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
@@ -99,9 +99,9 @@ export default (props) => {
   const renderInput = (params) => {
     // parity with Antd
     const shouldRenderSelected = !multiple && !open;
-    const selectedTitle = selectedListValue?.title ?? value.toString();
+    const selectedTitle = selectedListValue?.title ?? value?.toString() ?? "";
     const shouldHide = multiple && !open;
-    const renderValue = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? value.toString());
+    const renderValue = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? value?.toString() ?? "");
     return (
       <TextField 
         variant="standard"


### PR DESCRIPTION
When importing a query from for example json logic, show the imported value initially in autocomplete inputs that use an asyncFetch. Before this they would show no value at all until you clicked on them and they loaded all the options.