### PR TITLE
fix ValueSourcesItems type

### DIFF
--- a/packages/core/modules/index.d.ts
+++ b/packages/core/modules/index.d.ts
@@ -173,10 +173,6 @@ export type AnyRuleProperties = RuleProperties | RuleGroupExtProperties | RuleGr
 export type AnyGroupProperties = GroupProperties | SwitchGroupProperties | CaseGroupProperties;
 export type ItemProperties = AnyRuleProperties | GroupProperties;
 
-export type TypedValueSourceMap<T> = {
-  [key in ValueSource]: T;
-}
-
 interface ExtraActionProperties {
   // note: id can pre-generated for actions addRule, addGroup
   id?: string;

--- a/packages/ui/modules/index.d.ts
+++ b/packages/ui/modules/index.d.ts
@@ -12,7 +12,6 @@ import {
   ItemType,
   ItemProperties,
   ValueSource,
-  TypedValueSourceMap,
   ConfigContext, FactoryWithContext, RenderedReactElement, SerializedFunction,
   ConjsProps,
 
@@ -246,7 +245,7 @@ export interface ProviderProps {
 export type ValueSourceItem = {
   label: string;
 }
-type ValueSourcesItems = TypedValueSourceMap<ValueSourceItem>;
+type ValueSourcesItems = Array<[ValueSource, ValueSourceItem]>;
 
 export interface ValueSourcesProps {
   config?: Config;


### PR DESCRIPTION
I am currently adapting RAQB to shadcn-ui and I found a few type errors which I will subsequently create PRs for.