### PR TITLE
add `okType` to ConfirmModalProps

### DIFF
--- a/packages/ui/modules/index.d.ts
+++ b/packages/ui/modules/index.d.ts
@@ -261,6 +261,7 @@ export interface ConfirmModalProps {
   okText: string;
   cancelText?: string;
   title: string;
+  okType?: string;
 }
 
 export interface RuleErrorProps {


### PR DESCRIPTION
should this be a `string` instead of `"danger"`?