### PR TITLE
Use the selectedValue as search for the initial load

### DIFF
--- a/packages/ui/modules/hooks/useListValuesAutocomplete.jsx
+++ b/packages/ui/modules/hooks/useListValuesAutocomplete.jsx
@@ -157,14 +157,14 @@ const useListValuesAutocomplete = ({
     // Initial loading
     if (canInitialLoad && loadingCnt == 0 && asyncFectchCnt.current == 0) {
       (async () => {
-        await loadListValues();
+        await loadListValues(selectedValue);
       })();
     }
     // Unmount
     return () => {
       componentIsMounted.current--;
     };
-  }, [canInitialLoad]);
+  }, [canInitialLoad, selectedValue]);
 
   // Event handlers
   const onOpen = () => {


### PR DESCRIPTION
When importing a query that uses an async fetcher, it does an initial load when first clicking that field. This change makes that initial load use the imported selected value as the search term for that initial load.