### PR TITLE
Jsonlogic import export improvement

### DIFF
--- a/packages/core/modules/config/index.js
+++ b/packages/core/modules/config/index.js
@@ -75,14 +75,6 @@ const conjunctions = {
 
 //----------------------------  operators
 
-// Helper constants
-const jlTemplateInput = {
-  field: "jlField",
-  val: "jlArgs",  // For functions that use `val`
-  vals: ["jlArgs"], // For functions that use `vals`
-  twoVals: ["jlArgsFirst", "jlArgsSecond"]
-};
-
 const operators = {
   equal: {
     label: "==",
@@ -1643,7 +1635,6 @@ export const ConfigMixins = {
 
 let config = {
   conjunctions,
-  jlTemplateInput,
   operators,
   widgets,
   types,

--- a/packages/core/modules/config/index.js
+++ b/packages/core/modules/config/index.js
@@ -234,7 +234,7 @@ const operators = {
       "and"
     ],
     reversedOp: "not_between",
-    jsonLogic:  ({field, twoVals}) => ({ "<=": [twoVals[0], field, twoVals[1]] }),
+    jsonLogic: ({field, twoVals}) => ({ "<=": [twoVals[0], field, twoVals[1]] }),
     validateValues: (values) => {
       if (values[0] != undefined && values[1] != undefined) {
         return values[0] <= values[1];

--- a/packages/core/modules/export/jsonLogic.js
+++ b/packages/core/modules/export/jsonLogic.js
@@ -19,7 +19,7 @@ export const jsonLogicFormat = (item, config) => {
 
   const extendedConfig = extendConfig(config, undefined, false);
   const logic = formatItem(item, extendedConfig, meta, false, true);
-
+  
   // build empty data
   const {errors, usedFields} = meta;
   const {fieldSeparator} = extendedConfig.settings;
@@ -567,16 +567,17 @@ const formatLogic = (config, properties, formattedField, formattedValue, operato
   let fn = typeof operatorDefinition.jsonLogic == "function"
     ? operatorDefinition.jsonLogic
     : buildFnToFormatOp(operator, operatorDefinition, formattedField, formattedValue);
-  const args = [
+  /*  const args = [
     formattedField,
     operator,
     formattedValue,
     omit(operatorDefinition, opDefKeysToOmit),
     operatorOptions,
     fieldDefinition,
-  ];
-  let ruleQuery = fn.call(config.ctx, ...args);
-
+  ];*/
+  const functionInput = {field: formattedField, val: formattedValue, vals: formattedValue, twoVals: formattedValue};
+  //let ruleQuery = fn.call(functionInput);
+  let ruleQuery = fn(functionInput);
   if (isRev) {
     ruleQuery = { "!": ruleQuery };
   }

--- a/packages/core/modules/import/jsonLogic.js
+++ b/packages/core/modules/import/jsonLogic.js
@@ -1,5 +1,5 @@
 import uuid from "../utils/uuid";
-import {getOpCardinality, isJsonLogic, isValidFieldObject, shallowEqual, isVarEmptyObject, logger} from "../utils/stuff";
+import {getOpCardinality, isJsonLogic, isValidFieldObject, isValidForFieldMarker, shallowEqual, isVarEmptyObject, logger} from "../utils/stuff";
 import {getFieldConfig, extendConfig, normalizeField, getFuncConfig, iterateFuncs, getFieldParts} from "../utils/configUtils";
 import {getWidgetForFieldOp} from "../utils/ruleUtils";
 import {loadTree} from "./tree";
@@ -144,7 +144,7 @@ const matchAgainstTemplates = (jsonlogic, conv, meta, config, parentField, opera
           tempResponse["op"] = key;
           // With default config operators this should only be used to tell "equal" and "select_equals"
           // apart from each other
-          if (response && isValidFieldObject(tempResponse.jlField, conv)) {
+          if (response && isValidForFieldMarker(tempResponse.jlField, conv)) {
             const fieldKey = Object.keys(tempResponse.jlField)[0];
             if (conv.varKeys.includes(fieldKey) && typeof tempResponse.jlField[fieldKey] == "string") {
               const field = normalizeField(config, tempResponse.jlField[fieldKey], parentField);
@@ -202,8 +202,10 @@ const isTemplateMatch = (template, jsonlogic, conv, response = {"match": true, "
     const realValue = jsonlogic[key];
     if (value === jlTemplateInput.field) {
       // If jlFieldMarker is found in template we take the value from corresponding place in jsonlogic
-      // If the value is not in correct form then this is not a match.
-      if (isValidFieldObject(realValue, conv) || (typeof realValue === "object" && realValue !== null && "reduce" in realValue)) {
+      // If the value is not in correct form then this is not a match. Correct forms are field object, reduce and funcs.
+      if (
+        isValidForFieldMarker(realValue, conv)
+      ) {
         response.jlField = realValue;
       } else {
         response.match = false;

--- a/packages/core/modules/utils/stuff.js
+++ b/packages/core/modules/utils/stuff.js
@@ -220,6 +220,17 @@ export const isJsonLogic = (logic) => {
   return isJL;
 };
 
+/**
+ * Checks if the input object is a valid field object in the form { "var": "field" }.
+ * A valid field object:
+ *  - Is a non-null object
+ *  - Has exactly one key that matches any key in `conv.varKeys`
+ *  - The value of that key is a non-empty string
+ * 
+ * @param {*} obj - The object to validate
+ * @param {*} conv - The configuration containing `varKeys` for valid keys
+ * @returns {boolean} True if the object is a valid field object, otherwise false
+ */
 export const isValidFieldObject = (obj, conv) => {
   // Check if the input is an object and not null
   if (typeof obj !== "object" || obj === null) return false;
@@ -235,6 +246,16 @@ export const isValidFieldObject = (obj, conv) => {
   return typeof varValue === "string" && varValue.trim() !== "";
 };
 
+/**
+ * Checks if the input object is a "var empty" object in the form { "var": "" }.
+ * A "var empty" object:
+ *  - Is a non-null object
+ *  - Has exactly one key, "var"
+ *  - The value of the "var" key is an empty string
+ * 
+ * @param {*} obj - The object to validate
+ * @returns {boolean} True if the object is a "var empty" object, otherwise false
+ */
 export const isVarEmptyObject = (obj) => {
   // Check if the input is an object and not null
   if (typeof obj !== "object" || obj === null) return false;
@@ -243,6 +264,17 @@ export const isVarEmptyObject = (obj) => {
   return Object.keys(obj).length === 1 && obj.var === "";
 };
 
+/**
+ * Validates if the input object can appear in a JsonLogic field position.
+ * Valid forms for field markers include:
+ *  - A normal field object (e.g., { "var": "field" })
+ *  - A reduce operation (object containing "reduce" as a key)
+ *  - A function call where the object contains a single key matching `conv.funcs`
+ * 
+ * @param {*} obj - The object to validate
+ * @param {*} conv - The configuration containing valid functions under `funcs`
+ * @returns {boolean} True if the object is valid for a field marker, otherwise false
+ */
 export const isValidForFieldMarker = (obj, conv) => {
   return (
     isValidFieldObject(obj, conv) ||

--- a/packages/core/modules/utils/stuff.js
+++ b/packages/core/modules/utils/stuff.js
@@ -220,6 +220,29 @@ export const isJsonLogic = (logic) => {
   return isJL;
 };
 
+export const isValidFieldObject = (obj, conv) => {
+  // Check if the input is an object and not null
+  if (typeof obj !== "object" || obj === null) return false;
+
+  // Get the keys of the object
+  const keys = Object.keys(obj);
+
+  // Check if it has exactly one key and that key is "var"
+  if (keys.length !== 1 || !conv.varKeys.includes(keys[0])) return false;
+
+  // Check if the value of the "var" key is a non-empty string
+  const varValue = obj[keys[0]];
+  return typeof varValue === "string" && varValue.trim() !== "";
+};
+
+export const isVarEmptyObject = (obj) => {
+  // Check if the input is an object and not null
+  if (typeof obj !== "object" || obj === null) return false;
+
+  // Ensure the object has exactly one key, and it is "var" with an empty string value
+  return Object.keys(obj).length === 1 && obj.var === "";
+};
+
 export function sleep(delay) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);

--- a/packages/core/modules/utils/stuff.js
+++ b/packages/core/modules/utils/stuff.js
@@ -243,6 +243,14 @@ export const isVarEmptyObject = (obj) => {
   return Object.keys(obj).length === 1 && obj.var === "";
 };
 
+export const isValidForFieldMarker = (obj, conv) => {
+  return (
+    isValidFieldObject(obj, conv) ||
+    (typeof obj === "object" && obj !== null && "reduce" in obj) ||
+    (typeof obj === "object" && obj !== null && Object.keys(obj).some(key => key in conv.funcs))
+  );
+};
+
 export function sleep(delay) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);


### PR DESCRIPTION
Hello

I have previously mentioned my intention to refactor how JSONLogic import/export works. The main idea is to make everything work dynamically based on JSONLogic definitions found in the config, leveraging an expanded templateMatcher. My motivation was that the current implementation of JSONLogic import involves a lot of special-case logic (ie. arity etc) to recognize operators, that I found difficult to understand. I believe this new approach would make the import/export code more clear, maintainable, and less fragile while also making custom operators easier to implement. Also my previous contributions did not fully utilize the potential of the templateMatcher, and expanding its use felt relatively straightforward.

This branch is that idea mostly done. Both import and export just use the config jsonlogic definitions to figure out how to handle various operators.

You might notice from commits that I actually wrote this in December. Unfortunately I did not have time after that to really focus on this after that. As I see there are two main issues with this branch at the moment.

1. A test (loads tree with func SUM_OF_MULTISELECT in LHS) is failing because, in this case, the expected field object (e.g., { "var": "fieldName" }) is replaced by the custom function SUM_OF_MULTISELECT within the "between" operator. The templateMatcher relies on finding a field object in a specific location, and I'm uncertain how to handle this discrepancy. Question: Is the test incorrect, or should the code be extended to handle operators like this?

2. There is some issue with decompressing config. A test is failing and I have not really had time look into it.

Anyways, I have not really done anything with this since December, but if this approach seems useful I could probably finish it. Provided I get some pointers on how things are supposed to work regarding the whole sum_of_multiselect issue I mentioned. Mostly I just wanted to inform you that I made this in case you find it useful.
