### PR TITLE
Fix group operator's custom jsonLogic function not being called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Prevent potential prototype pollution in `OtherUtils.mergeIn` and `OtherUtils.setIn` (PR #1240)
   - Fix XSS vulnerability in antd package (PR #1243) (issue #1009)
   - Updated dependencies. `@babel/runtime` is now dep for all packages (PR #1246) (issue #964)
+  - Fix group operator's custom jsonLogic function not being called (PR #1242) (issue #1241)
 - 6.6.14
   - Fixed import from JsonLogic when like op is used inside group with some group op (PR #1225) (issue #1221)
   - Support React 19 (PR #1229) (issue #1205)

--- a/packages/core/modules/config/index.js
+++ b/packages/core/modules/config/index.js
@@ -297,7 +297,7 @@ const operators = {
       "and"
     ],
     reversedOp: "between",
-    jsonLogic:  (field, op, val) => ({"!": { "<=": [Array.isArray(val) ? val[0] : val, field, Array.isArray(val) ? val[1] : val] }}),
+    jsonLogic: (field, op, val) => ({"!": { "<=": [Array.isArray(val) ? val[0] : val, field, Array.isArray(val) ? val[1] : val] }}),
     jsonLogic2: "!<=",
     _jsonLogicIsExclamationOp: true,
     validateValues: (values) => {

--- a/packages/core/modules/index.d.ts
+++ b/packages/core/modules/index.d.ts
@@ -1193,7 +1193,7 @@ export type Operators<C = Config> = TypedMap<Operator<C>>;
 
 interface WidgetConfigForType {
   widgetProps?: Optional<Widget>;
-  opProps?: Optional<Operator>;
+  opProps?: Record<string, Optional<Operator>>;
   operators?: Array<string>;
   defaultOperator?: string;
   valueLabel?: string;

--- a/packages/tests/specs/QueryWithGroupsAndStructs.test.js
+++ b/packages/tests/specs/QueryWithGroupsAndStructs.test.js
@@ -15,6 +15,7 @@ describe("query with !struct and !group", () => {
         // }
       });
     });
+
     it("should handle custom operator in !group arrays", async () => {
       await with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator, "JsonLogic", async (qb, {onChange, expect_jlogic, expect_checks}) => {
         await expect_checks({
@@ -36,6 +37,93 @@ describe("query with !struct and !group", () => {
               }
             ]
           }
+        });
+      }, {
+        //ignoreLog
+      });
+    });
+
+    it("should handle custom operator with cardinality 0 in !group that has jsonLogic function", async () => {
+      await with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator2, "JsonLogic", async (qb, {onChange, expect_jlogic, expect_checks}) => {
+        await expect_checks({
+          "logic": {
+            "and": [
+              {
+                "custom2": [
+                  "--some-extra-data-1--",
+                  {"var": "cars"},
+                  {
+                    "and": [
+                      {
+                        "==": [{"var": "vendor"}, "Toyota"]
+                      }, {
+                        ">=": [{"var": "year"}, 2010]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      }, {
+        //ignoreLog
+      });
+    });
+
+    it("should handle custom operator with cardinality 1 in !group that has jsonLogic function", async () => {
+      await with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator3, "JsonLogic", async (qb, {onChange, expect_jlogic, expect_checks}) => {
+        await expect_checks({
+          "logic": {
+            "and": [
+              {
+                "custom3": [
+                  "--some-extra-data-1--",
+                  "cars",
+                  123,
+                  {
+                    "and": [
+                      {
+                        "==": [{"var": "vendor"}, "Toyota"]
+                      }, {
+                        ">=": [{"var": "year"}, 2010]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        });
+      }, {
+        //ignoreLog
+      });
+    });
+
+    it("should handle custom operator with cardinality 2 in !group that has jsonLogic function", async () => {
+      await with_qb_skins(configs.with_group_array_custom_operator, inits.with_group_array_custom_operator4, "JsonLogic", async (qb, {onChange, expect_jlogic, expect_checks}) => {
+        await expect_checks({
+          "logic": {
+            "and": [
+              {
+                "custom4": [
+                  "--some-extra-data-1--",
+                  "cars",
+                  123,
+                  456,
+                  {
+                    "and": [
+                      {
+                        "==": [{"var": "vendor"}, "Toyota"]
+                      }, {
+                        ">=": [{"var": "year"}, 2010]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
         });
       }, {
         //ignoreLog

--- a/packages/tests/support/configs.js
+++ b/packages/tests/support/configs.js
@@ -1497,7 +1497,10 @@ export const with_group_array_custom_operator = (BasicConfig) => ({
       conjunctions: ["AND", "OR"],
       showNot: true,
       operators: [
-        "custom_group_operator"
+        "custom_group_operator",
+        "custom_group_operator2",
+        "custom_group_operator3",
+        "custom_group_operator4",
       ],
       defaultOperator: "some",
       initialEmptyWhere: true, // if default operator is not in config.settings.groupOperators, true - to set no children, false - to add 1 empty
@@ -1523,7 +1526,13 @@ export const with_group_array_custom_operator = (BasicConfig) => ({
   },
   settings: {
     ...BasicConfig.settings,
-    groupOperators: [...BasicConfig.settings.groupOperators, "custom_group_operator"]
+    groupOperators: [
+      ...BasicConfig.settings.groupOperators,
+      "custom_group_operator",
+      "custom_group_operator2",
+      "custom_group_operator3",
+      "custom_group_operator4",
+    ]
   },
   operators: {
     ...BasicConfig.operators,
@@ -1533,7 +1542,78 @@ export const with_group_array_custom_operator = (BasicConfig) => ({
       cardinality: 0,
       jsonLogic: "custom_group_operator",
     },
-  }
+    custom_group_operator2: {
+      label: "custom_group_operator2",
+      cardinality: 0,
+      jsonLogic2: "custom2",
+      jsonLogic: (field, op, vals, _opDef, operatorOptions, _fieldDef) => {
+        return {
+          "custom2": [
+            "--some-extra-data-1--",
+            field,
+            operatorOptions?.get("having")
+          ]
+        };
+      },
+    },
+    custom_group_operator3: {
+      // this operator has cardinality 1
+      label: "custom_group_operator3",
+      cardinality: 1,
+      jsonLogic2: "custom3",
+      jsonLogic: (field, op, vals, _opDef, operatorOptions, _fieldDef) => {
+        return {
+          "custom3": [
+            "--some-extra-data-1--",
+            operatorOptions?.get("groupField"),
+            vals, // single number
+            operatorOptions?.get("having"),
+          ]
+        };
+      },
+    },
+    custom_group_operator4: {
+      // this operator has cardinality 2
+      label: "custom_group_operator4",
+      cardinality: 2,
+      jsonLogic2: "custom4",
+      jsonLogic: (field, op, vals, _opDef, operatorOptions, _fieldDef) => {
+        return {
+          "custom4": [
+            "--some-extra-data-1--",
+            operatorOptions?.get("groupField"),
+            vals[0],
+            vals[1],
+            operatorOptions?.get("having"),
+          ]
+        };
+      },
+    },
+  },
+  types: {
+    // Need to add custom group operators with cardinality > 0 for number widget in special "!group" type
+    ...BasicConfig.types,
+    "!group": {
+      ...BasicConfig.types["!group"],
+      widgets: {
+        ...BasicConfig.types["!group"].widgets,
+        number: {
+          ...BasicConfig.types["!group"].widgets.number,
+          operators: [
+            ...BasicConfig.types["!group"].widgets.number.operators,
+            "custom_group_operator3",
+            "custom_group_operator4",
+          ],
+          opProps: {
+            ...BasicConfig.types["!group"].widgets.number.opProps,
+            custom_group_operator4: {
+              textSeparators: ["from", "to"],
+            },
+          },
+        }
+      },
+    },
+  },
 });
 
 export const with_autocomplete = (BasicConfig) => ({

--- a/packages/tests/support/inits.js
+++ b/packages/tests/support/inits.js
@@ -1646,6 +1646,57 @@ export const with_group_array_custom_operator = {
   ]
 };
 
+export const with_group_array_custom_operator2 = {
+  "and": [
+    { "custom2": [
+      "--some-extra-data-1--",
+      { "var": "cars" },
+      { "and": [
+        {
+          "==": [ { "var": "vendor" }, "Toyota" ]
+        }, {
+          ">=": [ { "var": "year" }, 2010 ]
+        }
+      ] }
+    ] }
+  ]
+};
+
+export const with_group_array_custom_operator3 = {
+  "and": [
+    { "custom3": [
+      "--some-extra-data-1--",
+      "cars",
+      123,
+      { "and": [
+        {
+          "==": [ { "var": "vendor" }, "Toyota" ]
+        }, {
+          ">=": [ { "var": "year" }, 2010 ]
+        }
+      ] }
+    ] }
+  ]
+};
+
+export const with_group_array_custom_operator4 = {
+  "and": [
+    { "custom4": [
+      "--some-extra-data-1--",
+      "cars",
+      123,
+      456,
+      { "and": [
+        {
+          "==": [ { "var": "vendor" }, "Toyota" ]
+        }, {
+          ">=": [ { "var": "year" }, 2010 ]
+        }
+      ] }
+    ] }
+  ]
+};
+
 export const with_autocomplete_strict_a = {
   "and": [{
     "==": [


### PR DESCRIPTION
Change modifies formatGroup function behaviour for the root group so that when the group operator defines its own jsonLogic function, it uses formatLogic to resolve resultQuery. formatLogic function checks for custom function and invokes it when present.

Fixes #1241 