### PR TITLE
Potential fix for code scanning alert no. 11: Prototype-polluting function

### DIFF
--- a/packages/core/modules/utils/configSerialize.js
+++ b/packages/core/modules/utils/configSerialize.js
@@ -1,6 +1,6 @@
 import merge from "lodash/merge";
 import pick from "lodash/pick";
-import {isJsonLogic, isJSX, isDirtyJSX, cleanJSX, shallowEqual, isObject} from "./stuff";
+import {isJsonLogic, isJSX, isDirtyJSX, cleanJSX, shallowEqual, isObject, hasSafeOwnProperty} from "./stuff";
 import clone from "clone";
 import JL from "json-logic-js";
 import { addRequiredJsonLogicOperations, applyJsonLogic } from "./jsonLogic";
@@ -314,11 +314,7 @@ export const decompressConfig = (zipConfig, baseConfig, ctx) => {
         target = {};
       }
       for (let k in mixin) {
-        if (Object.prototype.hasOwnProperty.call(mixin, k)) {
-          // Block prototype-polluting keys
-          if (k === "__proto__" || k === "constructor") {
-            continue;
-          }
+        if (hasSafeOwnProperty(mixin, k)) {
           if (mixin[k] === "$$deleted") {
             delete target[k];
           } else {

--- a/packages/core/modules/utils/configSerialize.js
+++ b/packages/core/modules/utils/configSerialize.js
@@ -315,6 +315,10 @@ export const decompressConfig = (zipConfig, baseConfig, ctx) => {
       }
       for (let k in mixin) {
         if (Object.prototype.hasOwnProperty.call(mixin, k)) {
+          // Block prototype-polluting keys
+          if (k === "__proto__" || k === "constructor") {
+            continue;
+          }
           if (mixin[k] === "$$deleted") {
             delete target[k];
           } else {


### PR DESCRIPTION
Potential fix for [https://github.com/ukrbublik/react-awesome-query-builder/security/code-scanning/11](https://github.com/ukrbublik/react-awesome-query-builder/security/code-scanning/11)

To fix the issue, we need to explicitly block the special property names `__proto__` and `constructor` in the `_mergeDeep` function. This can be achieved by adding a check to skip these properties during the recursive merge process. This approach ensures that even if `mixin` contains malicious data, it cannot modify the prototype of `target` or any other object.

The changes will be made in the `_mergeDeep` function, specifically in the loop that iterates over the properties of `mixin` (lines 316–324). We will add a condition to skip the keys `__proto__` and `constructor`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
