### PR TITLE
feat: Add some missing type declarations for packages/core and packag…

### DIFF
--- a/packages/core/modules/index.d.ts
+++ b/packages/core/modules/index.d.ts
@@ -563,6 +563,9 @@ interface Autocomplete {
   // internal
   mergeListValues(oldValues: ListItems, newValues: ListItems, toStart?: boolean): ListItems;
   listValueToOption(listItem: ListItem): ListOptionUi;
+  fixListValuesGroupOrder(listValues: ListValues): ListValues;
+  optionsToListValues(vals: ListItems, listValues: ListValues, allowCustomValues: boolean): [ListItems, ListItems];
+  optionToListValue(val: ListItem | undefined, listValues: ListValues, allowCustomValues: boolean): ListItem | undefined;
 }
 interface ConfigUtils {
   areConfigsSame(config1: Config, config2: Config): boolean;
@@ -623,6 +626,8 @@ interface ListUtils {
   toListValue(value: string | number | ListItem, title?: string): ListItem | undefined; // create
   makeCustomListValue(value: string | number): ListItem; // create
   mapListValues<T>(listValues : ListValues, mapFn: (item: ListItem | undefined) => T | null) : T[];
+  getItemInListValues(listValues: ListValues, value: string | number): ListItem | undefined;
+  getValueInListValues(listValues: ListValues, value: string | number): string | number;
 }
 interface TreeUtils {
   jsToImmutable(value: any): AnyImmutable;
@@ -729,6 +734,15 @@ interface OtherUtils {
   isImmutable(value: any): boolean;
   toImmutableList(path: string[]): ImmutablePath;
   isTruthy<T>(value: T | false | null | undefined): value is T;
+  isObject<T>(value: T): boolean;
+  typeOf<T>(value: T): "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function" | "array";
+  isTypeOf<T>(value: T, type: "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function" | "array"): boolean;
+  isObjectOrArray<T>(value: T): boolean;
+}
+
+interface ConfigMixins {
+  addMixins: (config: Config, mixins: ConfigMixin) => Config;
+  removeMixins: (config: Config, mixins: ConfigMixin) => Config;
 }
 
 export interface Utils extends Import, Export,
@@ -751,7 +765,7 @@ export interface Utils extends Import, Export,
   ListUtils: ListUtils;
   TreeUtils: TreeUtils;
   OtherUtils: OtherUtils;
-
+  ConfigMixins: ConfigMixins;
   i18n: i18n;
 }
 

--- a/packages/ui/modules/index.d.ts
+++ b/packages/ui/modules/index.d.ts
@@ -588,12 +588,24 @@ export interface NumberFormat {
   numericFormatter: (val: number, numericFormatProps: NumericFormatProps) => string;
   numericParser: (str: string, numericFormatProps: NumericFormatProps, lastStrValue?: string, lastNumValue?: number) => number | undefined;
 }
+
+interface ReactUtils {
+  useOnPropsChanged(obj: React.Component): void;
+  isUsingLegacyReactDomRender(node: HTMLElement): boolean;
+  liteShouldComponentUpdate(self: React.Component, config: Record<string, string | ((nextValue: any, prevValue: any, nextProps: any, prevProps: any) => boolean)>) : 
+    (nextProps: any, nextState: any) => boolean;
+  pureShouldComponentUpdate(self: React.Component): (nextProps: any, nextState: any) => boolean;
+  bindActionCreators<T extends Record<string, (...args: any[]) => any>>(
+    actionCreators: T, 
+    config: any, 
+    dispatch: (action: any) => any
+  ): { [K in keyof T]: (...args: Parameters<T[K]>) => ReturnType<(action: any) => any> };
+}
+
 export interface Utils extends CoreUtils {
   NumberFormat: NumberFormat;
   ColorUtils: ColorUtils;
-  // ReactUtils: {
-  //   useOnPropsChanged(obj: ReactElement): void;
-  // }
+  ReactUtils: ReactUtils;
 }
 
 // Ignore "Multiple exports of name 'Utils'"


### PR DESCRIPTION
When using the **@react-awesome-query-builder/ui** module, I found that its TypeScript declaration files were partially missing. This led to a lack of complete type hints and compilation checks in my TypeScript project. This PR addresses these missing component properties and helper function types.