### PR TITLE
feat(antd): add v4/v5 compatibility for ButtonGroup component

### DIFF
--- a/packages/antd/modules/widgets/core/ButtonGroup.jsx
+++ b/packages/antd/modules/widgets/core/ButtonGroup.jsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { Button } from "antd";
-const ButtonGroup = Button.Group;
+import { Button, Space, version as antdVersion } from "antd";
 
-export default ({children, config: {settings}}) => {
-  const {renderSize} = settings;
-  return <ButtonGroup
-    size={renderSize}
-  >{children}</ButtonGroup>;
+export default ({ children, config: { settings } }) => {
+  const { renderSize } = settings;
+  const antdMajorVersion = parseInt(antdVersion.split(".")[0]);
+
+  if (antdMajorVersion >= 5) {
+    return <Space.Compact size={renderSize}>{children}</Space.Compact>;
+  } else {
+    const ButtonGroup = Button.Group;
+    return <ButtonGroup size={renderSize}>{children}</ButtonGroup>;
+  }
 };


### PR DESCRIPTION
## Tasks

- Replace deprecated Button.Group with Space.Compact for Ant Design v5
- Maintain backward compatibility with Button.Group for v4
- Add version detection logic to dynamically choose appropriate API
- Fixes ButtonGroup deprecation warnings in Ant Design v5

## Questions for Maintainers
1. Ant Design v4 Support Policy:
- The peerDependencies currently specify "antd": "^4.17.0 || ^5.0.0" - is this intentional?
- Do you plan to continue supporting v4, or transition to v5-only?

2. ButtonGroup Changes:
- Is the transition from Button.Group → Space.Compact appropriate?
- Does adding version detection logic align with the codebase policies?

3. Other Deprecated APIs:
- Should other files (FieldSelect, FieldDropdown, etc.) with deprecated APIs be handled the same way?

related #1218 