### PR TITLE
fix: ElasticSearch export - support multi-value operators using `terms` query

### DIFF
--- a/packages/core/modules/config/index.js
+++ b/packages/core/modules/config/index.js
@@ -468,7 +468,7 @@ const operators = {
     mongoFormatOp: function(...args) { return this.utils.mongoFormatOp1("$in", v => v, false, ...args); },
     reversedOp: "select_not_any_in",
     jsonLogic: "in",
-    elasticSearchQueryType: "term",
+    elasticSearchQueryType: "terms",
   },
   select_not_any_in: {
     isNotOp: true,
@@ -524,7 +524,7 @@ const operators = {
         ],
       }
     ],
-    elasticSearchQueryType: "term",
+    elasticSearchQueryType: "terms",
     mongoFormatOp: function(...args) { return this.utils.mongoFormatOp1("$in", v => v, false, ...args); },
   },
   multiselect_not_contains: {

--- a/packages/core/modules/export/elasticSearch.js
+++ b/packages/core/modules/export/elasticSearch.js
@@ -171,6 +171,12 @@ function determineField(fieldName, config) {
   return fieldName;
 }
 
+function formatTermValue(fieldName, value, syntax) {
+  return syntax === ES_7_SYNTAX
+    ? { [fieldName]: { value } }
+    : { [fieldName]: value };
+}
+
 function buildParameters(queryType, value, operator, fieldName, config, syntax) {
   const textField = determineField(fieldName, config);
   switch (queryType) {
@@ -187,10 +193,10 @@ function buildParameters(queryType, value, operator, fieldName, config, syntax) 
     return { [textField]: value[0] };
 
   case "term":
-    return syntax === ES_7_SYNTAX
-      ? { [fieldName]: {
-        value: value[0]
-      }} : { [fieldName]: value[0] };
+    return formatTermValue(fieldName, value[0], syntax);
+
+  case "terms":
+    return formatTermValue(fieldName, value, syntax);
 
   //todo: not used
   // need to add geo type into RAQB or remove this code
@@ -334,14 +340,8 @@ export function elasticSearchFormat(tree, config, syntax = ES_6_SYNTAX) {
       return;
     }
 
-    if (value && Array.isArray(value[0])) {
-      //TODO : Handle case where the value has multiple values such as in the case of a list
-      return value[0].map((val) =>
-        buildEsRule(field, [val], operator, extendedConfig, valueSrc, syntax)
-      );
-    } else {
-      return buildEsRule(field, value, operator, extendedConfig, valueSrc, syntax);
-    }
+    const normalizedValue = value && Array.isArray(value[0]) ? value[0] : value;
+    return buildEsRule(field, normalizedValue, operator, extendedConfig, valueSrc, syntax);
   }
 
   if (type === "group" || type === "rule_group") {

--- a/packages/tests/specs/QueryWithOperators.test.js
+++ b/packages/tests/specs/QueryWithOperators.test.js
@@ -145,15 +145,19 @@ describe("query with ops", () => {
               }
             },
             {
-              "term": {
-                "color": "yellow"
+              "terms": {
+                "color": [
+                  "yellow"
+                ]
               }
             },
             {
               "bool": {
                 "must_not": {
-                  "term": {
-                    "color": "green"
+                  "terms": {
+                    "color": [
+                      "green"
+                    ]
                   }
                 }
               }
@@ -371,16 +375,20 @@ describe("query with ops", () => {
               }
             },
             {
-              "term": {
-                "color": "yellow"
+              "terms": {
+                "color": [
+                  "yellow"
+                ]
               }
             },
             {
               "bool": {
                 "must_not": [
                   {
-                    "term": {
-                      "color": "green"
+                    "terms": {
+                      "color": [
+                        "green"
+                      ]
                     }
                   }
                 ]


### PR DESCRIPTION
This PR fixes how ElasticSearch DSL is generated for operators that accept multiple
values for a single field (e.g. `any in`, multi-select contains).

Previously, multi-select values were expanded into multiple `term` queries.
This does not match ElasticSearch semantics and produces unnecessarily complex DSL.

The change uses the native `terms` query for such operators, which correctly
represents field membership and aligns with ElasticSearch / OpenSearch behavior.

Single-value operators and non-ElasticSearch formatters are not affected.