### PR TITLE
fix(mui): support MUI v7+ slotProps in Autocomplete renderInput

### DIFF
--- a/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
+++ b/packages/mui/modules/widgets/value/MuiAutocomplete.jsx
@@ -103,25 +103,53 @@ export default (props) => {
     const selectedTitle = selectedListValue?.title ?? value?.toString() ?? "";
     const shouldHide = multiple && !open;
     const renderValue = shouldRenderSelected ? selectedTitle : (shouldHide ? "" : inputValue ?? value?.toString() ?? "");
-    return (
-      <TextField 
-        variant="standard"
-        {...params}
-        inputProps={{
+
+    // MUI v7 replaced TextField/Autocomplete `InputProps`/`inputProps` with `slotProps.input`/`slotProps.htmlInput`,
+    // and the `renderInput` params follow the same change. Support both shapes so the widget keeps working on
+    // MUI v5/v6 (InputProps/inputProps) as well as v7+ (slotProps).
+    const useSlotProps = params.slotProps != null;
+    const inheritedInputProps = (useSlotProps ? params.slotProps.input : params.InputProps) ?? {};
+    const endAdornment = (
+      <React.Fragment>
+        {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+        {inheritedInputProps.endAdornment}
+      </React.Fragment>
+    );
+
+    const compatInputProps = useSlotProps
+      ? {
+        slotProps: {
+          ...params.slotProps,
+          htmlInput: {
+            "aria-label": ariaLabel,
+            ...params.slotProps.htmlInput,
+            value: renderValue,
+          },
+          input: {
+            ...params.slotProps.input,
+            readOnly: readonly,
+            endAdornment,
+          },
+        },
+      }
+      : {
+        inputProps: {
           "aria-label": ariaLabel,
           ...params.inputProps,
           value: renderValue,
-        }}
-        InputProps={{
+        },
+        InputProps: {
           ...params.InputProps,
           readOnly: readonly,
-          endAdornment: (
-            <React.Fragment>
-              {isLoading ? <CircularProgress color="inherit" size={20}  /> : null}
-              {params.InputProps.endAdornment}
-            </React.Fragment>
-          ),
-        }}
+          endAdornment,
+        },
+      };
+
+    return (
+      <TextField
+        variant="standard"
+        {...params}
+        {...compatInputProps}
         size={renderSize}
         disabled={readonly}
         placeholder={placeholder}


### PR DESCRIPTION
## Summary

`MuiAutocomplete`'s `renderInput` reads `params.InputProps.endAdornment`. In MUI v7 the Autocomplete `renderInput` params replaced `InputProps`/`inputProps` with `slotProps.input`/`slotProps.htmlInput`, so on MUI v7+ (including v9) `params.InputProps` is `undefined` and this throws `TypeError: Cannot read properties of undefined (reading 'endAdornment')`, crashing any Autocomplete value widget.

This change detects the params shape at runtime and emits the matching props:
- **MUI v5/v6** (`params.slotProps` undefined): same `inputProps`/`InputProps` shape and merge order as before — no behavior change.
- **MUI v7+** (`params.slotProps` present): writes `slotProps.htmlInput`/`slotProps.input` and reads the inherited end adornment from `slotProps.input`.

It is scoped to the single crashing widget and does not change `peerDependencies`, so it is backward-compatible with the currently supported MUI range.

Fixes #1324

## Note on other widgets

The other MUI value widgets (`MuiText`, `MuiNumber`, `MuiTextArea`, `MuiPrice`, `MuiRange`, `MuiSlider`) also pass `InputProps`/`inputProps` to `TextField`, which MUI v7+ ignores (degraded behavior rather than a crash). Full MUI 7+ support across all widgets is tracked separately in #1298; this PR intentionally stays narrow and only fixes the reported crash.

## Testing

Verified against the `mui` package in this monorepo (which resolves `@mui/material@6.3.1` in dev — i.e. the v5/v6 code path is the one statically compiled here):

- `pnpm i` — succeeded.
- `pnpm --filter @react-awesome-query-builder/mui run eslint` — passed clean (exit 0).
- `pnpm --filter @react-awesome-query-builder/mui run tsc` (`tsc -p . --noEmit`) — passed clean (exit 0), so the change introduces no new type/syntax errors.

Honest caveats: these are static gates only. Because dev resolves MUI v6, the v7+ `slotProps` branch was reviewed by inspection (matching MUI's documented v7 `renderInput` params change) rather than exercised at runtime here. The v5/v6 branch preserves the original `inputProps`/`InputProps` shape and merge order, so existing behavior is unchanged. A full test-suite / browser run across MUI v7+ was not performed.